### PR TITLE
feat: configura mypy em modo strict para tipagem estática rigorosa

### DIFF
--- a/docs/prompts/02-especificacao/prompts.md
+++ b/docs/prompts/02-especificacao/prompts.md
@@ -60,3 +60,42 @@ pensamos no uso de IA nativo, voce analisou os steering antes de montar o requir
 
 **Resultado:**
 Releitura dos steering files revelou divergências. Requirements reescrito com: Ollama + LLaMA 3 como IA nativa, OpenAI SDK como drop-in replacement, SQLite para persistência, Drain3 para parsing, endpoints corretos (`api/v1/logs/...`), AIEngine sempre acionado, cobertura mínima de 30% e validação via Pydantic.
+
+
+---
+
+## P02-04 — Execução de tarefas de qualidade de código (black, isort, ruff, mypy)
+
+**Data:** 2025-05-07
+**Ferramenta:** Kiro
+
+**Prompt:**
+```
+Peguei 3 tasks, vou descrever abaixo. Com base nos specs e steerings desenvolva cada feature 
+e grave cada uma no commit e branch correspondente. Lembro que devemos seguir os padrões de 
+branch previamente configurados no .github. Cada prompt que eu fizer, incluindo esse deverá 
+ser documentado tal qual o já existente em docs > prompt.
+
+task: Configurar black, isort e ruff
+Tarefa Principal: #302
+Descrição: Configurar ferramentas de formatação e linting
+Critérios de Aceitação: (conforme tasks.md 17.2)
+Estimativa: 1h
+Requisitos: RNF-05
+
+task: Configurar mypy em modo strict
+Tarefa Principal: #302
+Descrição: Configurar mypy para tipagem estática rigorosa
+Critérios de Aceitação: (conforme tasks.md 17.1)
+Estimativa: 1h
+Requisitos: RNF-05
+```
+
+**Resultado:**
+Configuração de ferramentas de qualidade de código no pyproject.toml com:
+- mypy em modo strict (python_version = "3.11")
+- black com line-length = 100
+- isort com profile = "black"
+- ruff com select = ["E", "F", "I"]
+- pytest e hypothesis para testes
+- Validação de todas as ferramentas passando sem erros

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,143 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "logpulse-ia"
+version = "0.1.0"
+description = "API REST para análise inteligente de logs com IA local (Ollama + LLaMA 3)"
+readme = "README.md"
+requires-python = ">=3.11"
+license = {text = "MIT"}
+authors = [
+    {name = "LogPulse Team", email = "team@logpulse.local"}
+]
+keywords = ["logs", "ai", "analysis", "ollama", "llama3"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+
+dependencies = [
+    "fastapi>=0.104.0",
+    "uvicorn[standard]>=0.24.0",
+    "pydantic>=2.0.0",
+    "pydantic-settings>=2.0.0",
+    "drain3>=0.9.0",
+    "openai>=1.0.0",
+    "aiosqlite>=0.19.0",
+    "python-multipart>=0.0.6",
+]
+
+[project.optional-dependencies]
+dev = [
+    "mypy>=1.7.0",
+    "black>=23.12.0",
+    "isort>=5.13.0",
+    "ruff>=0.1.8",
+    "pytest>=7.4.0",
+    "pytest-asyncio>=0.21.0",
+    "pytest-cov>=4.1.0",
+    "hypothesis>=6.88.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/logpulse/logpulse-ia"
+Documentation = "https://github.com/logpulse/logpulse-ia#readme"
+Repository = "https://github.com/logpulse/logpulse-ia.git"
+Issues = "https://github.com/logpulse/logpulse-ia/issues"
+
+[tool.setuptools]
+packages = ["src"]
+
+# ============================================================================
+# mypy — Tipagem Estática Rigorosa (strict mode)
+# ============================================================================
+[tool.mypy]
+python_version = "3.11"
+strict = true
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+no_implicit_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_no_return = true
+warn_unreachable = true
+strict_equality = true
+exclude = [
+    "venv",
+    ".venv",
+    "build",
+    "dist",
+    ".git",
+]
+
+# ============================================================================
+# pytest — Framework de Testes
+# ============================================================================
+[tool.pytest.ini_options]
+minversion = "7.0"
+testpaths = ["tests"]
+python_files = ["test_*.py", "*_test.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
+asyncio_mode = "auto"
+addopts = [
+    "-v",
+    "--strict-markers",
+    "--tb=short",
+    "--disable-warnings",
+]
+markers = [
+    "unit: testes unitários",
+    "integration: testes de integração",
+    "slow: testes lentos",
+    "property: testes de propriedade (hypothesis)",
+]
+
+# ============================================================================
+# coverage — Cobertura de Testes
+# ============================================================================
+[tool.coverage.run]
+source = ["src"]
+branch = true
+omit = [
+    "*/tests/*",
+    "*/test_*.py",
+    "*/__init__.py",
+]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "def __repr__",
+    "raise AssertionError",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
+    "class .*\\bProtocol\\):",
+    "@(abc\\.)?abstractmethod",
+]
+precision = 2
+show_missing = true
+skip_covered = false
+
+[tool.coverage.html]
+directory = "htmlcov"
+
+# ============================================================================
+# hypothesis — Property-Based Testing
+# ============================================================================
+[tool.hypothesis]
+profile = "default"
+max_examples = 100

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,4 @@
+"""LogPulse IA — API REST para análise inteligente de logs com IA local."""
+
+__version__ = "0.1.0"
+__author__ = "LogPulse Team"


### PR DESCRIPTION
- Adiciona pyproject.toml com configuração de mypy strict
- Habilita strict = true para validação rigorosa de tipos
- Configura python_version = 3.11
- Adiciona validações: disallow_untyped_defs, disallow_untyped_calls, etc
- Valida com mypy --strict src/ sem erros
- Inclui configurações base de pytest, coverage e hypothesis

Tarefa: #302 (17.1)
Requisitos: RNF-05