### PR TITLE
feat: configura black, isort e ruff para formatação e linting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,68 @@
+# ============================================================================
+# LogPulse IA — Variáveis de Ambiente
+# ============================================================================
+# Copie este arquivo para .env e configure os valores para seu ambiente
+
+# API Configuration
+# Porta em que a API FastAPI será executada
+API_PORT=8000
+
+# Nível de log (DEBUG, INFO, WARNING, ERROR, CRITICAL)
+LOG_LEVEL=INFO
+
+# ============================================================================
+# Ollama Configuration
+# ============================================================================
+# URL do servidor Ollama (padrão: http://localhost:11434)
+# Certifique-se de que o Ollama está rodando antes de iniciar a aplicação
+OLLAMA_URL=http://localhost:11434
+
+# Modelo LLM a usar (padrão: llama3)
+# Modelos disponíveis: llama3, llama2, mistral, neural-chat, etc
+OLLAMA_MODEL=llama3
+
+# Timeout para chamadas ao Ollama em segundos (padrão: 30)
+OLLAMA_TIMEOUT=30
+
+# ============================================================================
+# Database Configuration
+# ============================================================================
+# Caminho para o arquivo SQLite (padrão: ./logpulse.db)
+# Use caminho absoluto ou relativo ao diretório de execução
+DATABASE_PATH=./logpulse.db
+
+# ============================================================================
+# Application Configuration
+# ============================================================================
+# Tamanho máximo de arquivo aceito em bytes (padrão: 52428800 = 50 MB)
+MAX_FILE_SIZE=52428800
+
+# Tamanho máximo de texto colado em caracteres (padrão: 100000)
+MAX_TEXT_SIZE=100000
+
+# Número máximo de entradas a amostrar para o LLM (padrão: 50)
+MAX_SAMPLE_ENTRIES=50
+
+# ============================================================================
+# Drain3 Configuration
+# ============================================================================
+# Profundidade da árvore de parsing (padrão: 4)
+DRAIN_DEPTH=4
+
+# Threshold de similaridade para agrupamento (padrão: 0.4)
+DRAIN_SIM_TH=0.4
+
+# ============================================================================
+# CORS Configuration
+# ============================================================================
+# Origens permitidas para CORS (separadas por vírgula)
+# Use "*" para permitir todas as origens (não recomendado em produção)
+CORS_ORIGINS=http://localhost:3000,http://localhost:8000
+
+# ============================================================================
+# Notas
+# ============================================================================
+# - Variáveis de ambiente têm precedência sobre arquivo de configuração
+# - Certifique-se de que o Ollama está rodando: ollama serve
+# - Para usar um modelo diferente, execute: ollama pull <modelo>
+# - Exemplo: ollama pull mistral

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,192 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "logpulse-ia"
+version = "0.1.0"
+description = "API REST para análise inteligente de logs com IA local (Ollama + LLaMA 3)"
+readme = "README.md"
+requires-python = ">=3.11"
+license = {text = "MIT"}
+authors = [
+    {name = "LogPulse Team", email = "team@logpulse.local"}
+]
+keywords = ["logs", "ai", "analysis", "ollama", "llama3"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+
+dependencies = [
+    "fastapi>=0.104.0",
+    "uvicorn[standard]>=0.24.0",
+    "pydantic>=2.0.0",
+    "pydantic-settings>=2.0.0",
+    "drain3>=0.9.0",
+    "openai>=1.0.0",
+    "aiosqlite>=0.19.0",
+    "python-multipart>=0.0.6",
+]
+
+[project.optional-dependencies]
+dev = [
+    "mypy>=1.7.0",
+    "black>=23.12.0",
+    "isort>=5.13.0",
+    "ruff>=0.1.8",
+    "pytest>=7.4.0",
+    "pytest-asyncio>=0.21.0",
+    "pytest-cov>=4.1.0",
+    "hypothesis>=6.88.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/logpulse/logpulse-ia"
+Documentation = "https://github.com/logpulse/logpulse-ia#readme"
+Repository = "https://github.com/logpulse/logpulse-ia.git"
+Issues = "https://github.com/logpulse/logpulse-ia/issues"
+
+[tool.setuptools]
+packages = ["src"]
+
+# ============================================================================
+# mypy — Tipagem Estática Rigorosa (strict mode)
+# ============================================================================
+[tool.mypy]
+python_version = "3.11"
+strict = true
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+no_implicit_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_no_return = true
+warn_unreachable = true
+strict_equality = true
+exclude = [
+    "venv",
+    ".venv",
+    "build",
+    "dist",
+    ".git",
+]
+
+# ============================================================================
+# black — Formatação de Código
+# ============================================================================
+[tool.black]
+line-length = 100
+target-version = ["py311"]
+include = '\.pyi?$'
+extend-exclude = '''
+/(
+  # diretórios
+  \.eggs
+  | \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | build
+  | dist
+)/
+'''
+
+# ============================================================================
+# isort — Organização de Imports
+# ============================================================================
+[tool.isort]
+profile = "black"
+line_length = 100
+include_trailing_comma = true
+use_parentheses = true
+ensure_newline_before_comments = true
+skip_glob = [".venv", "venv", "build", "dist"]
+known_first_party = ["src"]
+
+# ============================================================================
+# ruff — Linting Rápido
+# ============================================================================
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I"]
+ignore = [
+    "E501",  # line too long (black cuida disso)
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["src"]
+
+# ============================================================================
+# pytest — Framework de Testes
+# ============================================================================
+[tool.pytest.ini_options]
+minversion = "7.0"
+testpaths = ["tests"]
+python_files = ["test_*.py", "*_test.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
+asyncio_mode = "auto"
+addopts = [
+    "-v",
+    "--strict-markers",
+    "--tb=short",
+    "--disable-warnings",
+]
+markers = [
+    "unit: testes unitários",
+    "integration: testes de integração",
+    "slow: testes lentos",
+    "property: testes de propriedade (hypothesis)",
+]
+
+# ============================================================================
+# coverage — Cobertura de Testes
+# ============================================================================
+[tool.coverage.run]
+source = ["src"]
+branch = true
+omit = [
+    "*/tests/*",
+    "*/test_*.py",
+    "*/__init__.py",
+]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "def __repr__",
+    "raise AssertionError",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
+    "class .*\\bProtocol\\):",
+    "@(abc\\.)?abstractmethod",
+]
+precision = 2
+show_missing = true
+skip_covered = false
+
+[tool.coverage.html]
+directory = "htmlcov"
+
+# ============================================================================
+# hypothesis — Property-Based Testing
+# ============================================================================
+[tool.hypothesis]
+profile = "default"
+max_examples = 100


### PR DESCRIPTION
- Adiciona configuração de black com line-length=100
- Adiciona configuração de isort com profile=black
- Adiciona configuração de ruff com select=[E, F, I]
- Valida com black --check, isort --check-only, ruff check sem erros
- Adiciona .env.example com variáveis de ambiente documentadas
- Inclui configurações completas de mypy, pytest, coverage e hypothesis

Tarefa: #302 (17.2)
Requisitos: RNF-05