### PR TITLE
feat: implementar AIEngine com Ollama

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,68 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+*.egg
+*.egg-info/
+dist/
+build/
+eggs/
+parts/
+var/
+sdist/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-link
+MANIFEST
+
+# Virtual environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# pytest / coverage
+.pytest_cache/
+.coverage
+.coverage.*
+htmlcov/
+coverage.xml
+*.cover
+
+# hypothesis
+.hypothesis/
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# IDEs
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs gerados localmente
+*.log
+
+# SQLite
+*.db
+*.sqlite3
+
+# Variáveis de ambiente
+.env
+.env.local
+.env.*.local
+
+# Kiro
+.kiro/specs/**/.config.kiro

--- a/.kiro/specs/logpulse-ia/tasks.md
+++ b/.kiro/specs/logpulse-ia/tasks.md
@@ -210,7 +210,7 @@ Este documento contém as tarefas de implementação para o LogPulse IA, uma API
   - **Estimativa:** 1 hora (validação)
   - _Requisitos: RF-03.*, RNF-03_
 
-- [ ] 5. Implementar Analyzer de Anomalias
+- [x] 5. Implementar Analyzer de Anomalias
   - **Descrição:** Criar componente que detecta anomalias (spikes, stack traces) em um LogStream
   - **Critérios de Aceitação:**
     - ✅ Interface abstrata `LogAnalyzer` com método `analyze()`

--- a/.kiro/specs/logpulse-ia/tasks.md
+++ b/.kiro/specs/logpulse-ia/tasks.md
@@ -283,7 +283,7 @@ Este documento contém as tarefas de implementação para o LogPulse IA, uma API
     - **Estimativa:** 2h
     - _Requisitos: RF-04.3_
   
-- [ ] 6. Implementar AIEngine com Ollama
+- [-] 6. Implementar AIEngine com Ollama
   - **Descrição:** Criar componente que usa Ollama/LLaMA 3 para gerar diagnóstico inteligente a partir da análise
   - **Critérios de Aceitação:**
     - ✅ Interface abstrata `AIEngine` com método `diagnose()`

--- a/docs/prompts/04-implementacao-modelos/prompts.md
+++ b/docs/prompts/04-implementacao-modelos/prompts.md
@@ -1,0 +1,72 @@
+# Prompts — Etapa 04: Implementação dos Modelos de Dados com Pydantic
+
+Prompts utilizados durante a execução da Tarefa 2 — Implementar modelos de dados com Pydantic.
+
+---
+
+## P04-01 — Execução da Tarefa 2: Implementar modelos de dados com Pydantic
+
+**Data:** 2026-05-12
+**Ferramenta:** Kiro
+
+**Prompt:**
+```
+vamos codificar a issue que eu estou desse projeto.
+Implementar modelos de dados com Pydantic
+Spec: logpulse-ia
+Descricao
+Criar todos os modelos Pydantic que representam dados do sistema (logs, análises, diagnósticos)
+Criterios de Aceitacao
+Enum SeverityLevel com valores: DEBUG, INFO, WARNING, ERROR, CRITICAL
+Modelo LogEntry com campos obrigatórios e flags de inferência
+Modelo LogTemplate com pattern, occurrences, sample_messages
+Modelo Spike com start_time, end_time, error_count
+Modelo AnalysisResult com contadores e distribuição
+Modelo Hypothesis com description, probability, action
+Modelo AIDiagnosis com summary, probable_cause, hypotheses (min 3)
+Schemas de API: LogFileUpload, LogTextUpload, LogAnalysisResponse, LogListParams
+Paralelismo e Dependencias
+[AVISO] Depende de: Tarefa 1 (estrutura do projeto)
+Estimativa
+3-4 horas
+Requisitos
+RF-03.1, RF-03.4, RF-04.2, RF-04.4, RF-05.2, RF-05.3, RF-01.1, RF-02.2, RF-07.1
+nao perca tempo, quero codificação, agora!
+```
+
+**Contexto:**
+- Tarefa 2 do arquivo `.kiro/specs/logpulse-ia/tasks.md`
+- Branch: `feature/implementar-modelos-pydantic`
+- Arquivo alvo: `src/models/schemas.py`
+
+**Critérios de Aceitação atendidos:**
+- ✅ Enum `SeverityLevel` com valores: DEBUG, INFO, WARNING, ERROR, CRITICAL
+- ✅ Modelo `LogEntry` com campos obrigatórios e flags de inferência (`level_inferred`, `timestamp_inferred`)
+- ✅ Modelo `LogTemplate` com pattern, occurrences, sample_messages (limitado a 5)
+- ✅ Modelo `Spike` com start_time, end_time, error_count + validação `end_time > start_time`
+- ✅ Modelo `AnalysisResult` com contadores e severity_distribution
+- ✅ Modelo `Hypothesis` com description, probability ("alta"/"média"/"baixa"), action
+- ✅ Modelo `AIDiagnosis` com summary, probable_cause, hypotheses (mínimo 3)
+- ✅ Schemas de API: LogFileUpload, LogTextUpload, LogAnalysisResponse, LogListParams
+
+**Resultado:**
+- `src/models/schemas.py` — todos os modelos implementados com validações Pydantic
+- `src/models/__init__.py` — exporta todos os modelos
+- `tests/models/test_schemas.py` — 71 testes unitários e property-based, todos passando
+- Commit: `feat: implementa modelos Pydantic para logs, analises e diagnosticos`
+- PR #317 aberto para revisão
+
+---
+
+## P04-02 — Confirmação de conformidade com a issue
+
+**Data:** 2026-05-12
+**Ferramenta:** Kiro
+
+**Prompt:**
+```
+esta de acordo com o que era requisito na issue???
+```
+
+**Resultado:**
+Validação item a item confirmou 100% de conformidade com todos os critérios de aceitação e Definition of Done da issue. 71/71 testes passando.

--- a/docs/prompts/05-parser-drain3/prompts.md
+++ b/docs/prompts/05-parser-drain3/prompts.md
@@ -1,0 +1,114 @@
+# Prompts — Etapa 05: Implementação do Parser de Logs com Drain3
+
+Prompts utilizados durante a execução da Tarefa 3 — Implementar Parser de Logs com Drain3.
+
+---
+
+## P05-01 — Análise de próxima tarefa prioritária
+
+**Data:** 2026-05-12
+**Ferramenta:** Kiro
+
+**Prompt:**
+```
+voce deve analisar qual a proxima tarefa, que é mais prioritaria, que não depende de outras tarefas...
+```
+
+**Resultado:**
+Análise do tasks.md identificou a Tarefa 3 (Parser de Logs com Drain3) como a mais prioritária, pois todas as tarefas seguintes (Analyzer, AIEngine, Repository, API) dependem dela. Tarefa 2 já estava concluída.
+
+---
+
+## P05-02 — Execução da Tarefa 3: Parser de Logs com Drain3
+
+**Data:** 2026-05-12
+**Ferramenta:** Kiro
+
+**Prompt:**
+```
+sim, pode iniciar agora mesmo
+```
+
+**Contexto:**
+- Tarefa 3 do arquivo `.kiro/specs/logpulse-ia/tasks.md`
+- Branch: `feature/parser-drain3` (criada a partir de `main`)
+- Dependência: Tarefa 2 (modelos Pydantic) — já concluída
+
+**Critérios de Aceitação atendidos:**
+- ✅ Interface abstrata `LogParser` com métodos `parse()` e `get_templates()`
+- ✅ `Drain3LogParser` configurado com depth=4 e sim_th=0.4
+- ✅ Reconhece 3 formatos: JSON estruturado, Syslog RFC 3164, texto livre
+- ✅ Normaliza aliases: WARN→WARNING, ERR→ERROR, FATAL→CRITICAL, TRACE→DEBUG
+- ✅ Infere timestamp quando ausente (flag `timestamp_inferred=True`)
+- ✅ Infere level quando ausente (default INFO, flag `level_inferred=True`)
+- ✅ Extrai templates com Drain3 e atribui template_id
+- ✅ Coleta até 5 sample_messages por template
+- ✅ Processa 1000 linhas sem erros (RNF-03)
+- ✅ Linhas malformadas não interrompem processamento
+
+**Arquivos criados:**
+- `src/parsers/base.py` — interface abstrata `LogParser`
+- `src/parsers/normalizer.py` — normalização de severidade e inferência de timestamp
+- `src/parsers/drain3_parser.py` — `Drain3LogParser` concreto com Drain3
+- `src/parsers/__init__.py` — exporta módulo
+- `conftest.py` — configuração de path para pytest
+- `tests/parsers/test_normalizer.py` — testes do normalizador
+- `tests/parsers/test_drain3_parser.py` — testes do parser
+
+**Resultado:**
+- 70 testes passando (unitários + property-based com Hypothesis)
+- Commit: `feat: implementa parser de logs com Drain3 (JSON, Syslog, texto livre)`
+- PR #318 aberto para revisão
+
+---
+
+## P05-03 — Correção de erro na API do Drain3
+
+**Data:** 2026-05-12
+**Ferramenta:** Kiro
+
+**Prompt:**
+```
+deu certo??
+```
+
+**Contexto:**
+Durante os testes, identificado que a versão 0.9.11 do Drain3 retorna um `dict` com chaves `cluster_id` e `template_mined` diretamente, em vez de um objeto `cluster`. O código foi corrigido para usar a API correta.
+
+**Resultado:**
+Correção aplicada em `_process_template()`. Todos os 70 testes passando após a correção.
+
+---
+
+## P05-04 — Análise de dependências entre PRs
+
+**Data:** 2026-05-12
+**Ferramenta:** Kiro
+
+**Prompt:**
+```
+as tarefas q estao aguardando o review para merge, tem que ser aceitas na sequencia?
+uma depende da outra nao é??
+```
+
+**Resultado:**
+Análise confirmou cadeia de dependências: #315 (mypy) → #317 (modelos) → #318 (parser). Recomendação: mergear na sequência para manter histórico limpo. Na prática, o #318 já contém os arquivos dos PRs anteriores.
+
+---
+
+## P05-05 — Correção do .gitignore e erro no git pull
+
+**Data:** 2026-05-12
+**Ferramenta:** Kiro
+
+**Prompt:**
+```
+eu fiz um git pull origin main e deu erro [pasta logpulse_ia.egg-info bloqueando merge]
+essa pasta egg é de alguma issue do projeto? eu que estava implementando??
+```
+
+**Contexto:**
+A pasta `logpulse_ia.egg-info/` foi gerada automaticamente pelo `pip install -e .` durante o desenvolvimento. Não faz parte de nenhuma issue — é artefato do setuptools. O projeto não tinha `.gitignore`.
+
+**Resultado:**
+Criado `.gitignore` completo para Python incluindo: `__pycache__/`, `*.egg-info/`, `.hypothesis/`, `.pytest_cache/`, `.mypy_cache/`, `.venv/`, `.env`, `*.db`, entre outros. Solução para o pull: `rmdir /s /q logpulse_ia.egg-info` seguido de `git pull origin main`.

--- a/docs/prompts/06-analyzer-anomalias/prompts.md
+++ b/docs/prompts/06-analyzer-anomalias/prompts.md
@@ -1,0 +1,133 @@
+# Prompts — Tarefa 5: Implementar Analyzer de Anomalias
+
+## Contexto
+
+Esta documentação registra os prompts e decisões tomadas durante a implementação da Tarefa 5 do LogPulse IA: o módulo de análise de anomalias (`src/analyzer/`).
+
+---
+
+## Prompt 1 — Criar interface abstrata LogAnalyzer
+
+**Prompt:**
+> Crie uma interface abstrata `LogAnalyzer` em `src/analyzer/base.py` usando ABC do Python. O método abstrato `analyze` deve receber `entries: list[LogEntry]` e `templates: list[LogTemplate]` e retornar `AnalysisResult`. Use tipagem completa com type hints e docstrings em português no estilo Google.
+
+**Resultado:**
+- Criado `src/analyzer/base.py` com classe `LogAnalyzer(ABC)`
+- Método abstrato `analyze()` com assinatura completa
+- Impossível instanciar diretamente (lança `TypeError`)
+
+---
+
+## Prompt 2 — Implementar AnomalyDetector
+
+**Prompt:**
+> Implemente `AnomalyDetector` em `src/analyzer/detector.py` como subclasse concreta de `LogAnalyzer`. O detector deve:
+> - Retornar `insufficient_data=True` se houver menos de 2 entradas
+> - Calcular distribuição de severidade (contagem por `SeverityLevel`)
+> - Calcular `error_count` (ERROR + CRITICAL) e `warning_count`
+> - Detectar spikes de erro usando janela deslizante de 60s com threshold ≥10
+> - Detectar e agrupar stack traces Python, Java e Go
+> - Agrupar entradas por `template_id`
+>
+> Use constantes nomeadas: `_SPIKE_WINDOW_SECONDS = 60`, `_SPIKE_THRESHOLD = 10`, `_MIN_ENTRIES_FOR_ANALYSIS = 2`.
+
+**Resultado:**
+- Criado `src/analyzer/detector.py` com `AnomalyDetector`
+- Funções auxiliares privadas: `_compute_severity_distribution`, `_detect_spikes`, `_extract_stack_traces`
+- Regex para detecção de stack traces Python, Java e Go
+
+---
+
+## Prompt 3 — Implementar detecção de spikes com janela deslizante
+
+**Prompt:**
+> A função `_detect_spikes` deve usar janela deslizante de 60 segundos. Para cada posição `i` na lista de erros ordenada por timestamp, colete todas as entradas dentro de `[timestamp[i], timestamp[i] + 60s]`. Se houver ≥10 entradas na janela, crie um `Spike` e avance o ponteiro para depois do fim da janela. O `Spike` deve ter `end_time > start_time` (se forem iguais, adicione 1 segundo).
+
+**Decisões técnicas:**
+- Filtra apenas entradas com `severity in {ERROR, CRITICAL}` e `timestamp is not None`
+- Ordena por timestamp antes de aplicar a janela
+- Avança `i` pelo tamanho da janela para evitar spikes sobrepostos
+- Coleta `template_ids` únicos das entradas do spike
+
+---
+
+## Prompt 4 — Implementar agrupamento de stack traces
+
+**Prompt:**
+> A função `_extract_stack_traces` deve detectar e agrupar stack traces multi-linha. Use regex para identificar o início de cada tipo:
+> - Python: `Traceback \(most recent call last\)`
+> - Java: `Exception in thread|at\s+[\w\.$]+\([\w\.]+\.java:\d+\)`
+> - Go: `panic:|goroutine\s+\d+\s+\[`
+>
+> Agrupe linhas de continuação até encontrar uma linha não relacionada. Descarte traces de linha única.
+
+**Bug encontrado e corrigido:**
+Durante os testes, foi identificado que o modelo `LogEntry` tem `str_strip_whitespace = True` (configurado via `model_config`), o que remove espaços iniciais de `raw_content`. A lógica de continuação de traceback Python verificava `raw.startswith("  ")` — que nunca seria verdadeiro após o strip.
+
+**Correção aplicada em `detector.py`:**
+```python
+# Antes (bugado):
+elif current_type == "python" and (
+    raw.startswith("  ") or raw.startswith("\t") or "Error:" in raw
+):
+
+# Depois (corrigido):
+elif current_type == "python" and (
+    raw.startswith("  ")
+    or raw.startswith("\t")
+    or raw.startswith("File ")
+    or "Error:" in raw
+    or "Exception:" in raw
+    or "Warning:" in raw
+):
+```
+
+---
+
+## Prompt 5 — Escrever testes unitários abrangentes
+
+**Prompt:**
+> Escreva testes unitários em `tests/analyzer/test_detector.py` cobrindo todos os critérios de aceitação da Tarefa 5:
+> - Interface abstrata não pode ser instanciada
+> - Agrupamento por `template_id`
+> - Distribuição de severidade soma 100% das entradas
+> - Spike com exatamente 10 erros em 60s
+> - Spike com 15 erros em 60s
+> - Sem spike com 9 erros em 60s
+> - Sem spike com 10 erros em 61s
+> - Python traceback multi-linha agrupado em 1 evento
+> - Java stacktrace multi-linha agrupado em 1 evento
+> - Go panic multi-linha agrupado em 1 evento
+> - `insufficient_data=True` para 0 e 1 entradas
+> - Casos: 0, 1, 2, 10, 100 entradas
+
+**Resultado:**
+- 45 testes unitários organizados em 7 classes
+- Helper `make_entry()` para criação de `LogEntry` nos testes
+- Helper `make_error_entries_in_window()` para cenários de spike
+
+---
+
+## Prompt 6 — Adicionar property-based tests com Hypothesis
+
+**Prompt:**
+> Adicione testes de propriedade usando `hypothesis` para validar invariantes do `AnomalyDetector`:
+> 1. A distribuição de severidade sempre soma igual a `total_entries` (para qualquer combinação de severidades)
+> 2. `insufficient_data=True` sempre que há < 2 entradas (para n=0 e n=1)
+> 3. Todo spike detectado tem `error_count >= 10` (para qualquer número de erros ≥10 na janela)
+>
+> Anote cada teste com `**Validates: Requirements RF-04.X**`.
+
+**Resultado:**
+- 4 property-based tests com `@given` e `@settings`
+- Estratégias customizadas para gerar entradas válidas
+- Todos os testes passam com 20-50 exemplos gerados
+
+---
+
+## Resultado Final
+
+- **49 novos testes** em `tests/analyzer/test_detector.py`
+- **190 testes totais** passando (141 existentes + 49 novos)
+- **1 bug corrigido** em `src/analyzer/detector.py` (continuação de traceback Python com `raw_content` stripped)
+- Cobertura de todos os critérios de aceitação da Tarefa 5

--- a/docs/prompts/07-ai-engine-ollama/prompts.md
+++ b/docs/prompts/07-ai-engine-ollama/prompts.md
@@ -1,0 +1,148 @@
+# Prompts — AIEngine com Ollama (Task 6)
+
+## Contexto
+
+Esta tarefa implementa o componente `AIEngine` responsável por gerar diagnósticos inteligentes a partir da análise de logs, utilizando o Ollama/LLaMA 3 como backend de LLM via OpenAI SDK (drop-in replacement).
+
+---
+
+## Arquivos Criados
+
+| Arquivo | Descrição |
+|---------|-----------|
+| `src/exceptions.py` | Hierarquia de exceções customizadas do LogPulse IA |
+| `src/ai/__init__.py` | Exportações públicas do módulo AI |
+| `src/ai/base.py` | Interface abstrata `AIEngine` com ABC |
+| `src/ai/ollama_engine.py` | Implementação `OllamaAIEngine` com Ollama/LLaMA 3 |
+| `tests/ai/__init__.py` | Pacote de testes do módulo AI |
+| `tests/ai/test_ollama_engine.py` | Testes abrangentes com mocks do Ollama |
+
+---
+
+## Decisões de Design
+
+### 1. Interface Abstrata com ABC
+
+A classe `AIEngine` usa `ABC` (Abstract Base Class) para garantir que implementações concretas respeitem o contrato do método `diagnose`. Isso permite trocar o provedor de LLM no futuro sem alterar o código cliente.
+
+```python
+class AIEngine(ABC):
+    @abstractmethod
+    def diagnose(
+        self,
+        analysis: AnalysisResult,
+        sample_entries: List[LogEntry],
+    ) -> AIDiagnosis: ...
+```
+
+### 2. Amostragem Estratificada
+
+Para respeitar o requisito RNF-04 (enviar apenas amostras ao LLM, nunca o log completo), implementamos amostragem estratificada com proporções fixas:
+
+- **70%** de erros (ERROR + CRITICAL) — foco nos problemas críticos
+- **20%** de warnings — contexto de degradação
+- **10%** de outros (INFO, DEBUG) — contexto geral
+- **Máximo de 50 entradas** — limita o tamanho do prompt
+
+### 3. Verificação de Disponibilidade
+
+Antes de qualquer chamada ao LLM, o engine verifica se o Ollama está acessível via conexão TCP na porta 11434. Isso evita timeouts desnecessários e fornece mensagem de erro clara ao usuário.
+
+### 4. Retry com Backoff Exponencial
+
+Implementado com 3 tentativas e delays de 1s, 2s, 4s entre elas. Captura `APITimeoutError` e `APIConnectionError` do SDK OpenAI. Após esgotar as tentativas, lança `AIEngineTimeoutError`.
+
+### 5. Validação de Resposta via Pydantic
+
+A resposta do LLM é parseada como JSON e validada pelo schema `AIDiagnosis` do Pydantic, que garante:
+- Mínimo de 3 hipóteses (`min_length=3`)
+- Campo `action` não vazio em cada hipótese
+- Campo `probability` com valores válidos ("alta", "média", "baixa")
+
+---
+
+## Prompt do Sistema
+
+O prompt do sistema instrui o LLM a:
+1. Responder **apenas** com JSON válido (sem texto adicional)
+2. Seguir o schema `AIDiagnosis` exatamente
+3. Gerar **exatamente 3 ou mais hipóteses** ordenadas por probabilidade
+4. Incluir **ação concreta** em cada hipótese
+5. Basear-se **apenas** nas informações fornecidas (sem inventar dados)
+
+---
+
+## Hierarquia de Exceções
+
+```
+LogPulseError
+├── AIEngineError
+│   ├── AIEngineTimeoutError    # Timeout após 3 tentativas
+│   └── AIEngineUnavailableError # Ollama indisponível
+├── ParsingError
+├── AnalysisError
+└── StorageError
+```
+
+---
+
+## Testes Implementados (26 testes)
+
+### Interface Abstrata (3 testes)
+- `AIEngine` não pode ser instanciado diretamente
+- `OllamaAIEngine` é subclasse de `AIEngine`
+- Subclasse sem `diagnose` lança `TypeError`
+
+### Amostragem Estratificada (8 testes)
+- Lista vazia retorna lista vazia
+- Menos de 50 entradas retorna todas
+- Amostragem limita a 50 entradas
+- ~70% de erros na amostra
+- ~20% de warnings na amostra
+- ~10% de outros na amostra
+- Funciona com apenas erros
+- Retorna exatamente `max_entries` quando há suficientes
+
+### Disponibilidade do Ollama (3 testes)
+- `AIEngineUnavailableError` quando Ollama está indisponível
+- Prossegue para chamada quando disponível
+- Mensagem de erro contém "ollama serve"
+
+### Timeout e Retry (4 testes)
+- `AIEngineTimeoutError` após 3 tentativas
+- Cliente chamado exatamente 3 vezes
+- Delays corretos: 1s, 2s (backoff exponencial)
+- `APIConnectionError` também aciona retry
+
+### Parsing e Validação (6 testes)
+- Resposta válida parseada para `AIDiagnosis`
+- Diagnóstico tem pelo menos 3 hipóteses
+- Menos de 3 hipóteses lança `ValidationError`
+- `action` vazio lança `ValidationError`
+- Bloco markdown é removido antes do parse
+- Cada hipótese tem `action` não vazio
+
+### Integração (2 testes)
+- `diagnose` funciona com entradas de amostra reais
+- Sucesso na segunda tentativa após falha na primeira
+
+---
+
+## Prompt Utilizado para Geração
+
+```
+Implementar AIEngine com Ollama (Task 6) para o projeto LogPulse IA.
+
+Criar:
+1. src/exceptions.py — hierarquia de exceções customizadas
+2. src/ai/base.py — interface abstrata AIEngine com ABC
+3. src/ai/ollama_engine.py — OllamaAIEngine com:
+   - Cliente OpenAI SDK → http://localhost:11434/v1
+   - Amostragem estratificada (70% erros, 20% warnings, 10% outros, máx 50)
+   - Prompt do sistema para análise de logs
+   - Chamada com modelo llama3
+   - Timeout 30s + retry backoff exponencial (1s, 2s, 4s)
+   - Verificação de disponibilidade via socket TCP
+   - Validação de resposta com Pydantic AIDiagnosis
+4. tests/ai/test_ollama_engine.py — 26 testes com unittest.mock
+```

--- a/src/ai/__init__.py
+++ b/src/ai/__init__.py
@@ -1,0 +1,9 @@
+"""Módulo de integração com motores de IA do LogPulse IA.
+
+Exporta a interface abstrata AIEngine e a implementação OllamaAIEngine.
+"""
+
+from src.ai.base import AIEngine
+from src.ai.ollama_engine import OllamaAIEngine
+
+__all__ = ["AIEngine", "OllamaAIEngine"]

--- a/src/ai/base.py
+++ b/src/ai/base.py
@@ -1,0 +1,46 @@
+"""Interface abstrata para motores de IA do LogPulse IA."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import List
+
+from src.models.schemas import AIDiagnosis, AnalysisResult, LogEntry
+
+
+class AIEngine(ABC):
+    """Interface abstrata para implementações de motor de IA.
+
+    Todo motor de IA concreto deve implementar o método `diagnose`,
+    garantindo que o contrato seja respeitado independentemente do
+    provedor de LLM utilizado (Ollama, OpenAI, Gemini, etc.).
+
+    Example:
+        >>> class MyEngine(AIEngine):
+        ...     def diagnose(self, analysis, sample_entries):
+        ...         return AIDiagnosis(...)
+    """
+
+    @abstractmethod
+    def diagnose(
+        self,
+        analysis: AnalysisResult,
+        sample_entries: List[LogEntry],
+    ) -> AIDiagnosis:
+        """Gera diagnóstico inteligente a partir da análise de logs.
+
+        Args:
+            analysis: Resultado da análise de anomalias contendo
+                distribuição de severidade, spikes e stack traces.
+            sample_entries: Amostra estratificada de entradas de log
+                para contextualizar o diagnóstico.
+
+        Returns:
+            Diagnóstico estruturado com causa provável, hipóteses
+            ordenadas por probabilidade e sugestão de correção.
+
+        Raises:
+            AIEngineTimeoutError: Se o LLM não responder dentro do timeout.
+            AIEngineUnavailableError: Se o serviço de LLM estiver indisponível.
+        """
+        ...

--- a/src/ai/ollama_engine.py
+++ b/src/ai/ollama_engine.py
@@ -1,0 +1,343 @@
+"""Implementação do AIEngine usando Ollama/LLaMA 3 via OpenAI SDK."""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import random
+import socket
+import time
+from typing import List
+
+import openai
+
+from src.ai.base import AIEngine
+from src.exceptions import AIEngineTimeoutError, AIEngineUnavailableError
+from src.models.schemas import AIDiagnosis, AnalysisResult, Hypothesis, LogEntry, SeverityLevel
+
+# ---------------------------------------------------------------------------
+# Constantes de configuração
+# ---------------------------------------------------------------------------
+
+_OLLAMA_BASE_URL = "http://localhost:11434/v1"
+_OLLAMA_HOST = "localhost"
+_OLLAMA_PORT = 11434
+_MODEL_NAME = "llama3"
+
+# Timeout por chamada ao Ollama (segundos)
+_CALL_TIMEOUT_SECONDS = 30
+
+# Configuração de retry com backoff exponencial
+_MAX_RETRIES = 3
+_RETRY_DELAYS = [1, 2, 4]  # segundos entre tentativas
+
+# Amostragem estratificada
+_MAX_SAMPLE_ENTRIES = 50
+_ERROR_RATIO = 0.70   # 70% de erros (ERROR + CRITICAL)
+_WARNING_RATIO = 0.20  # 20% de warnings
+_OTHER_RATIO = 0.10   # 10% de outros (INFO, DEBUG)
+
+# Níveis considerados "erro" para amostragem
+_ERROR_LEVELS = {SeverityLevel.ERROR, SeverityLevel.CRITICAL}
+_WARNING_LEVELS = {SeverityLevel.WARNING}
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Prompt do sistema
+# ---------------------------------------------------------------------------
+
+_SYSTEM_PROMPT = """Você é um especialista em análise de logs de sistemas de produção.
+Sua tarefa é analisar logs fornecidos e gerar um diagnóstico estruturado em JSON.
+
+Regras obrigatórias:
+1. Responda APENAS com JSON válido, sem texto adicional antes ou depois.
+2. O JSON deve seguir exatamente o schema fornecido.
+3. Gere EXATAMENTE 3 ou mais hipóteses de causa raiz.
+4. Cada hipótese DEVE ter um campo "action" não vazio com uma ação concreta.
+5. O campo "probability" deve ser exatamente "alta", "média" ou "baixa".
+6. Baseie-se APENAS nas informações fornecidas — não invente eventos ou timestamps.
+7. As hipóteses devem ser ordenadas da maior para a menor probabilidade.
+
+Schema JSON esperado:
+{
+  "summary": "Resumo claro do problema identificado",
+  "probable_cause": "Causa raiz mais provável",
+  "hypotheses": [
+    {
+      "description": "Descrição da hipótese",
+      "probability": "alta",
+      "action": "Ação concreta para investigar ou corrigir",
+      "related_line": null
+    }
+  ],
+  "suggested_fix": "Sugestão de correção ou próximos passos",
+  "confidence": 0.85
+}"""
+
+
+def _build_user_prompt(analysis: AnalysisResult, sample_entries: List[LogEntry]) -> str:
+    """Constrói o prompt do usuário com os dados de análise e amostras.
+
+    Args:
+        analysis: Resultado da análise de anomalias.
+        sample_entries: Amostra estratificada de entradas de log.
+
+    Returns:
+        Prompt formatado para envio ao LLM.
+    """
+    lines = [
+        "## Análise de Logs",
+        "",
+        f"**Total de entradas:** {analysis.total_entries}",
+        f"**Erros (ERROR + CRITICAL):** {analysis.error_count}",
+        f"**Warnings:** {analysis.warning_count}",
+        f"**Dados insuficientes:** {analysis.insufficient_data}",
+        "",
+    ]
+
+    # Distribuição de severidade
+    if analysis.severity_distribution:
+        lines.append("**Distribuição por severidade:**")
+        for level, count in analysis.severity_distribution.items():
+            lines.append(f"  - {level.value}: {count}")
+        lines.append("")
+
+    # Spikes detectados
+    if analysis.spikes:
+        lines.append(f"**Spikes detectados:** {len(analysis.spikes)}")
+        for spike in analysis.spikes:
+            lines.append(
+                f"  - {spike.error_count} erros entre "
+                f"{spike.start_time.isoformat()} e {spike.end_time.isoformat()}"
+            )
+        lines.append("")
+
+    # Stack traces
+    if analysis.stack_traces:
+        lines.append(f"**Stack traces detectados:** {len(analysis.stack_traces)}")
+        for i, trace in enumerate(analysis.stack_traces[:3], 1):
+            lines.append(f"  Stack trace {i}:")
+            for trace_line in trace.split("\n")[:5]:
+                lines.append(f"    {trace_line}")
+        lines.append("")
+
+    # Templates
+    if analysis.templates:
+        lines.append(f"**Templates de log ({len(analysis.templates)} padrões):**")
+        for tmpl in analysis.templates[:5]:
+            lines.append(f"  - [{tmpl.occurrences}x] {tmpl.pattern}")
+        lines.append("")
+
+    # Amostras de log
+    if sample_entries:
+        lines.append(f"**Amostras de log ({len(sample_entries)} entradas):**")
+        for entry in sample_entries:
+            ts = entry.timestamp.isoformat() if entry.timestamp else "sem timestamp"
+            lines.append(f"  [{entry.severity.value}] {ts} — {entry.raw_content[:200]}")
+        lines.append("")
+
+    lines.append("Gere o diagnóstico em JSON conforme o schema especificado.")
+
+    return "\n".join(lines)
+
+
+def _stratified_sample(entries: List[LogEntry], max_entries: int = _MAX_SAMPLE_ENTRIES) -> List[LogEntry]:
+    """Realiza amostragem estratificada das entradas de log.
+
+    Seleciona entradas respeitando as proporções:
+    - 70% de erros (ERROR + CRITICAL)
+    - 20% de warnings (WARNING)
+    - 10% de outros (INFO, DEBUG)
+
+    Args:
+        entries: Lista completa de entradas de log.
+        max_entries: Número máximo de entradas na amostra (padrão: 50).
+
+    Returns:
+        Lista amostrada com no máximo max_entries entradas.
+    """
+    if not entries:
+        return []
+
+    if len(entries) <= max_entries:
+        return list(entries)
+
+    # Separa por categoria
+    errors = [e for e in entries if e.severity in _ERROR_LEVELS]
+    warnings = [e for e in entries if e.severity in _WARNING_LEVELS]
+    others = [e for e in entries if e.severity not in _ERROR_LEVELS and e.severity not in _WARNING_LEVELS]
+
+    # Calcula quantidades por categoria
+    n_errors = math.floor(max_entries * _ERROR_RATIO)
+    n_warnings = math.floor(max_entries * _WARNING_RATIO)
+    n_others = max_entries - n_errors - n_warnings
+
+    # Ajusta se não há entradas suficientes em alguma categoria
+    actual_errors = min(n_errors, len(errors))
+    actual_warnings = min(n_warnings, len(warnings))
+    actual_others = min(n_others, len(others))
+
+    # Redistribui slots não utilizados
+    remaining = max_entries - actual_errors - actual_warnings - actual_others
+    if remaining > 0:
+        # Tenta completar com erros primeiro, depois warnings, depois outros
+        extra_errors = min(remaining, len(errors) - actual_errors)
+        actual_errors += extra_errors
+        remaining -= extra_errors
+
+    if remaining > 0:
+        extra_warnings = min(remaining, len(warnings) - actual_warnings)
+        actual_warnings += extra_warnings
+        remaining -= extra_warnings
+
+    if remaining > 0:
+        extra_others = min(remaining, len(others) - actual_others)
+        actual_others += extra_others
+
+    # Amostra aleatória de cada categoria
+    sampled_errors = random.sample(errors, actual_errors) if actual_errors > 0 else []
+    sampled_warnings = random.sample(warnings, actual_warnings) if actual_warnings > 0 else []
+    sampled_others = random.sample(others, actual_others) if actual_others > 0 else []
+
+    return sampled_errors + sampled_warnings + sampled_others
+
+
+def _check_ollama_availability() -> None:
+    """Verifica se o Ollama está disponível na porta 11434.
+
+    Tenta estabelecer uma conexão TCP com o servidor Ollama.
+    Lança AIEngineUnavailableError se a conexão falhar.
+
+    Raises:
+        AIEngineUnavailableError: Se o Ollama não estiver acessível.
+    """
+    try:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.settimeout(3)
+        result = sock.connect_ex((_OLLAMA_HOST, _OLLAMA_PORT))
+        sock.close()
+        if result != 0:
+            raise AIEngineUnavailableError(
+                f"Ollama não está disponível em {_OLLAMA_BASE_URL}. "
+                "Execute: ollama serve"
+            )
+    except OSError as exc:
+        raise AIEngineUnavailableError(
+            f"Ollama não está disponível em {_OLLAMA_BASE_URL}. "
+            "Execute: ollama serve"
+        ) from exc
+
+
+def _parse_llm_response(content: str) -> AIDiagnosis:
+    """Parseia a resposta do LLM para um objeto AIDiagnosis.
+
+    Args:
+        content: Conteúdo textual retornado pelo LLM.
+
+    Returns:
+        Objeto AIDiagnosis validado pelo Pydantic.
+
+    Raises:
+        pydantic.ValidationError: Se a resposta não atender ao schema.
+        json.JSONDecodeError: Se o conteúdo não for JSON válido.
+    """
+    # Remove possíveis blocos de código markdown
+    cleaned = content.strip()
+    if cleaned.startswith("```"):
+        lines = cleaned.split("\n")
+        # Remove primeira linha (```json ou ```) e última linha (```)
+        cleaned = "\n".join(lines[1:-1]) if lines[-1].strip() == "```" else "\n".join(lines[1:])
+
+    data = json.loads(cleaned)
+    return AIDiagnosis.model_validate(data)
+
+
+class OllamaAIEngine(AIEngine):
+    """Motor de IA usando Ollama/LLaMA 3 via OpenAI SDK.
+
+    Implementa o contrato AIEngine utilizando o servidor Ollama local
+    como backend de LLM, com suporte a timeout, retry com backoff
+    exponencial e validação de resposta via Pydantic.
+
+    Attributes:
+        _client: Cliente OpenAI SDK configurado para o Ollama local.
+
+    Example:
+        >>> engine = OllamaAIEngine()
+        >>> diagnosis = engine.diagnose(analysis_result, sample_entries)
+        >>> print(diagnosis.summary)
+    """
+
+    def __init__(self) -> None:
+        """Inicializa o OllamaAIEngine com cliente OpenAI SDK."""
+        self._client = openai.OpenAI(
+            base_url=_OLLAMA_BASE_URL,
+            api_key="ollama",  # Ollama não requer API key real
+            timeout=_CALL_TIMEOUT_SECONDS,
+        )
+
+    def diagnose(
+        self,
+        analysis: AnalysisResult,
+        sample_entries: List[LogEntry],
+    ) -> AIDiagnosis:
+        """Gera diagnóstico inteligente a partir da análise de logs.
+
+        Verifica disponibilidade do Ollama, realiza amostragem estratificada,
+        envia prompt ao LLaMA 3 e valida a resposta com Pydantic.
+
+        Args:
+            analysis: Resultado da análise de anomalias.
+            sample_entries: Lista de entradas de log para amostragem.
+
+        Returns:
+            Diagnóstico estruturado com hipóteses e sugestões.
+
+        Raises:
+            AIEngineUnavailableError: Se o Ollama não estiver disponível.
+            AIEngineTimeoutError: Se todas as tentativas esgotarem o timeout.
+        """
+        # Verifica disponibilidade antes de processar
+        _check_ollama_availability()
+
+        # Amostragem estratificada
+        sampled = _stratified_sample(sample_entries)
+
+        # Constrói prompts
+        user_prompt = _build_user_prompt(analysis, sampled)
+
+        # Tenta com retry e backoff exponencial
+        last_exception: Exception | None = None
+
+        for attempt in range(1, _MAX_RETRIES + 1):
+            logger.info("Tentativa %d de %d ao Ollama", attempt, _MAX_RETRIES)
+            try:
+                response = self._client.chat.completions.create(
+                    model=_MODEL_NAME,
+                    messages=[
+                        {"role": "system", "content": _SYSTEM_PROMPT},
+                        {"role": "user", "content": user_prompt},
+                    ],
+                    temperature=0.3,
+                )
+
+                content = response.choices[0].message.content or ""
+                return _parse_llm_response(content)
+
+            except (openai.APITimeoutError, openai.APIConnectionError) as exc:
+                last_exception = exc
+                logger.warning(
+                    "Tentativa %d falhou: %s. %s",
+                    attempt,
+                    type(exc).__name__,
+                    "Aguardando antes de tentar novamente..." if attempt < _MAX_RETRIES else "Esgotadas todas as tentativas.",
+                )
+                if attempt < _MAX_RETRIES:
+                    time.sleep(_RETRY_DELAYS[attempt - 1])
+
+        raise AIEngineTimeoutError(
+            f"Ollama não respondeu após {_MAX_RETRIES} tentativas. "
+            f"Último erro: {last_exception}"
+        ) from last_exception

--- a/src/analyzer/__init__.py
+++ b/src/analyzer/__init__.py
@@ -1,0 +1,9 @@
+"""Módulo de análise de anomalias do LogPulse IA."""
+
+from src.analyzer.base import LogAnalyzer
+from src.analyzer.detector import AnomalyDetector
+
+__all__ = [
+    "LogAnalyzer",
+    "AnomalyDetector",
+]

--- a/src/analyzer/base.py
+++ b/src/analyzer/base.py
@@ -1,0 +1,35 @@
+"""Interface abstrata para analyzers de log do LogPulse IA."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import List
+
+from src.models.schemas import AnalysisResult, LogEntry, LogTemplate
+
+
+class LogAnalyzer(ABC):
+    """Interface abstrata para implementações de analyzer de log.
+
+    Todo analyzer concreto deve implementar o método `analyze`,
+    garantindo que o contrato seja respeitado independentemente
+    da estratégia de detecção de anomalias utilizada.
+    """
+
+    @abstractmethod
+    def analyze(
+        self,
+        entries: List[LogEntry],
+        templates: List[LogTemplate],
+    ) -> AnalysisResult:
+        """Analisa um conjunto de entradas de log e detecta anomalias.
+
+        Args:
+            entries: Lista de entradas de log normalizadas.
+            templates: Templates extraídos pelo parser (Drain3).
+
+        Returns:
+            Resultado da análise contendo distribuição de severidade,
+            spikes detectados, stack traces agrupados e metadados.
+        """
+        ...

--- a/src/analyzer/detector.py
+++ b/src/analyzer/detector.py
@@ -1,0 +1,283 @@
+"""Detector de anomalias concreto para o LogPulse IA."""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from datetime import timedelta
+from typing import Dict, List, Optional, Tuple
+
+from src.analyzer.base import LogAnalyzer
+from src.models.schemas import (
+    AnalysisResult,
+    LogEntry,
+    LogTemplate,
+    SeverityLevel,
+    Spike,
+)
+
+# ---------------------------------------------------------------------------
+# Constantes de detecção
+# ---------------------------------------------------------------------------
+
+# Janela de tempo para detecção de spikes (segundos)
+_SPIKE_WINDOW_SECONDS = 60
+
+# Mínimo de erros na janela para caracterizar spike
+_SPIKE_THRESHOLD = 10
+
+# Níveis considerados "erro" para detecção de spike
+_ERROR_LEVELS = {SeverityLevel.ERROR, SeverityLevel.CRITICAL}
+
+# Mínimo de entradas para análise confiável
+_MIN_ENTRIES_FOR_ANALYSIS = 2
+
+# ---------------------------------------------------------------------------
+# Regex para detecção de stack traces
+# ---------------------------------------------------------------------------
+
+_RE_PYTHON_TRACEBACK = re.compile(
+    r"Traceback \(most recent call last\)", re.IGNORECASE
+)
+
+_RE_JAVA_STACKTRACE = re.compile(
+    r"(?:Exception in thread|at\s+[\w\.$]+\([\w\.]+\.java:\d+\))",
+    re.IGNORECASE,
+)
+
+_RE_GO_PANIC = re.compile(
+    r"(?:panic:|goroutine\s+\d+\s+\[)",
+    re.IGNORECASE,
+)
+
+
+class AnomalyDetector(LogAnalyzer):
+    """Detector de anomalias em streams de log.
+
+    Implementa detecção de:
+    - Distribuição de severidade por nível
+    - Spikes de erro (≥10 erros ERROR/CRITICAL em janela de 60s)
+    - Stack traces multi-linha (Python, Java, Go)
+    - Agrupamento por template_id
+    """
+
+    def analyze(
+        self,
+        entries: List[LogEntry],
+        templates: List[LogTemplate],
+    ) -> AnalysisResult:
+        """Analisa entradas de log e detecta anomalias.
+
+        Args:
+            entries: Lista de entradas de log normalizadas.
+            templates: Templates extraídos pelo Drain3.
+
+        Returns:
+            AnalysisResult com distribuição, spikes e stack traces.
+        """
+        total = len(entries)
+
+        # Dados insuficientes
+        if total < _MIN_ENTRIES_FOR_ANALYSIS:
+            return AnalysisResult(
+                total_entries=total,
+                insufficient_data=True,
+                templates=templates,
+            )
+
+        severity_distribution = _compute_severity_distribution(entries)
+        error_count = (
+            severity_distribution.get(SeverityLevel.ERROR, 0)
+            + severity_distribution.get(SeverityLevel.CRITICAL, 0)
+        )
+        warning_count = severity_distribution.get(SeverityLevel.WARNING, 0)
+
+        spikes = _detect_spikes(entries)
+        stack_traces = _extract_stack_traces(entries)
+
+        return AnalysisResult(
+            total_entries=total,
+            severity_distribution=severity_distribution,
+            error_count=error_count,
+            warning_count=warning_count,
+            spikes=spikes,
+            stack_traces=stack_traces,
+            templates=templates,
+            insufficient_data=False,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Funções auxiliares
+# ---------------------------------------------------------------------------
+
+
+def _compute_severity_distribution(
+    entries: List[LogEntry],
+) -> Dict[SeverityLevel, int]:
+    """Calcula a distribuição de entradas por nível de severidade.
+
+    Args:
+        entries: Lista de entradas de log.
+
+    Returns:
+        Dicionário com contagem por SeverityLevel.
+    """
+    distribution: Dict[SeverityLevel, int] = defaultdict(int)
+    for entry in entries:
+        distribution[entry.severity] += 1
+    return dict(distribution)
+
+
+def _detect_spikes(entries: List[LogEntry]) -> List[Spike]:
+    """Detecta spikes de erro usando janela deslizante de 60 segundos.
+
+    Um spike é caracterizado por ≥10 erros (ERROR ou CRITICAL)
+    em uma janela deslizante de 60 segundos.
+
+    Args:
+        entries: Lista de entradas de log ordenadas por timestamp.
+
+    Returns:
+        Lista de Spike detectados.
+    """
+    # Filtra apenas entradas de erro com timestamp válido
+    error_entries = [
+        e for e in entries
+        if e.severity in _ERROR_LEVELS and e.timestamp is not None
+    ]
+
+    if len(error_entries) < _SPIKE_THRESHOLD:
+        return []
+
+    # Ordena por timestamp
+    error_entries.sort(key=lambda e: e.timestamp)  # type: ignore[arg-type, return-value]
+
+    spikes: List[Spike] = []
+    window = timedelta(seconds=_SPIKE_WINDOW_SECONDS)
+    i = 0
+
+    while i < len(error_entries):
+        start_ts = error_entries[i].timestamp
+        assert start_ts is not None
+
+        # Coleta todas as entradas dentro da janela
+        window_entries = [
+            e for e in error_entries[i:]
+            if e.timestamp is not None and e.timestamp - start_ts <= window
+        ]
+
+        if len(window_entries) >= _SPIKE_THRESHOLD:
+            end_ts = window_entries[-1].timestamp
+            assert end_ts is not None
+
+            # Garante que end_time > start_time
+            if end_ts == start_ts:
+                end_ts = start_ts + timedelta(seconds=1)
+
+            template_ids = list({
+                e.template_id for e in window_entries
+                if e.template_id is not None
+            })
+
+            spikes.append(
+                Spike(
+                    start_time=start_ts,
+                    end_time=end_ts,
+                    error_count=len(window_entries),
+                    template_ids=template_ids,
+                )
+            )
+            # Avança para depois do fim da janela atual
+            i += len(window_entries)
+        else:
+            i += 1
+
+    return spikes
+
+
+def _extract_stack_traces(entries: List[LogEntry]) -> List[str]:
+    """Detecta e agrupa stack traces multi-linha nas entradas de log.
+
+    Suporta:
+    - Python: Traceback (most recent call last)
+    - Java: Exception in thread / at ClassName.method(File.java:N)
+    - Go: panic: / goroutine N [
+
+    Args:
+        entries: Lista de entradas de log.
+
+    Returns:
+        Lista de stack traces agrupados como strings.
+    """
+    stack_traces: List[str] = []
+    current_trace: List[str] = []
+    current_type: Optional[str] = None
+
+    for entry in entries:
+        raw = entry.raw_content
+
+        if _RE_PYTHON_TRACEBACK.search(raw):
+            if current_trace:
+                stack_traces.append("\n".join(current_trace))
+            current_trace = [raw]
+            current_type = "python"
+
+        elif _RE_JAVA_STACKTRACE.search(raw):
+            if current_type == "java":
+                current_trace.append(raw)
+            else:
+                if current_trace:
+                    stack_traces.append("\n".join(current_trace))
+                current_trace = [raw]
+                current_type = "java"
+
+        elif _RE_GO_PANIC.search(raw):
+            if current_type == "go":
+                current_trace.append(raw)
+            else:
+                if current_trace:
+                    stack_traces.append("\n".join(current_trace))
+                current_trace = [raw]
+                current_type = "go"
+
+        elif current_type == "python" and (
+            raw.startswith("  ")
+            or raw.startswith("\t")
+            or raw.startswith("File ")
+            or "Error:" in raw
+            or "Exception:" in raw
+            or "Warning:" in raw
+        ):
+            # Continuação de traceback Python
+            # Nota: raw_content é stripped pelo modelo, então verificamos
+            # tanto prefixos com espaço (caso não-stripped) quanto sem.
+            current_trace.append(raw)
+
+        elif current_type == "java" and (
+            raw.strip().startswith("at ") or "Caused by:" in raw
+        ):
+            # Continuação de stacktrace Java
+            current_trace.append(raw)
+
+        elif current_type == "go" and (
+            raw.strip().startswith("goroutine") or raw.strip().startswith("\t")
+        ):
+            # Continuação de panic Go
+            current_trace.append(raw)
+
+        else:
+            # Linha não relacionada — fecha trace atual se existir
+            if current_trace and len(current_trace) > 1:
+                stack_traces.append("\n".join(current_trace))
+            elif current_trace:
+                # Trace de linha única — descarta
+                pass
+            current_trace = []
+            current_type = None
+
+    # Fecha trace pendente
+    if current_trace and len(current_trace) > 1:
+        stack_traces.append("\n".join(current_trace))
+
+    return stack_traces

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -1,0 +1,62 @@
+"""Hierarquia de exceções customizadas do LogPulse IA.
+
+Define todas as exceções específicas do domínio, organizadas em uma
+hierarquia que facilita o tratamento granular de erros.
+"""
+
+from __future__ import annotations
+
+
+class LogPulseError(Exception):
+    """Exceção base do LogPulse IA.
+
+    Todas as exceções customizadas do sistema herdam desta classe,
+    permitindo capturar qualquer erro do domínio com um único handler.
+    """
+
+
+class AIEngineError(LogPulseError):
+    """Erro ao comunicar com o motor de IA (Ollama, OpenAI, etc.).
+
+    Subclasse base para erros relacionados à integração com LLMs.
+    """
+
+
+class AIEngineTimeoutError(AIEngineError):
+    """Timeout esgotado após todas as tentativas de chamada ao LLM.
+
+    Lançada quando o AIEngine esgota as 3 tentativas com backoff
+    exponencial sem obter resposta dentro do limite de 30 segundos.
+    """
+
+
+class AIEngineUnavailableError(AIEngineError):
+    """Motor de IA indisponível (serviço não está em execução).
+
+    Lançada quando não é possível estabelecer conexão com o Ollama
+    na porta 11434 antes de processar a requisição.
+    """
+
+
+class ParsingError(LogPulseError):
+    """Erro ao parsear conteúdo de log.
+
+    Lançada quando o parser não consegue processar o conteúdo
+    fornecido, mesmo após tentativas de fallback.
+    """
+
+
+class AnalysisError(LogPulseError):
+    """Erro durante a análise de anomalias.
+
+    Lançada quando o Analyzer encontra um estado inválido ou
+    inconsistente durante o processamento do LogStream.
+    """
+
+
+class StorageError(LogPulseError):
+    """Erro ao persistir ou recuperar dados do SQLite.
+
+    Lançada quando operações de leitura, escrita ou deleção
+    no banco de dados falham de forma irrecuperável.
+    """

--- a/tests/ai/__init__.py
+++ b/tests/ai/__init__.py
@@ -1,0 +1,1 @@
+"""Testes para o módulo de integração com motores de IA."""

--- a/tests/ai/test_ollama_engine.py
+++ b/tests/ai/test_ollama_engine.py
@@ -1,0 +1,532 @@
+"""Testes para OllamaAIEngine e AIEngine.
+
+Cobre interface abstrata, amostragem estratificada, disponibilidade,
+timeout, retry, parsing de resposta e validação de schema.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+from datetime import datetime, timezone
+from typing import List
+from unittest.mock import MagicMock, patch
+
+import openai
+import pytest
+from pydantic import ValidationError
+
+from src.ai.base import AIEngine
+from src.ai.ollama_engine import (
+    OllamaAIEngine,
+    _MAX_RETRIES,
+    _MAX_SAMPLE_ENTRIES,
+    _stratified_sample,
+)
+from src.exceptions import AIEngineTimeoutError, AIEngineUnavailableError
+from src.models.schemas import (
+    AIDiagnosis,
+    AnalysisResult,
+    Hypothesis,
+    LogEntry,
+    SeverityLevel,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers de fixture
+# ---------------------------------------------------------------------------
+
+
+def _make_entry(severity: SeverityLevel, message: str = "test log") -> LogEntry:
+    """Cria uma LogEntry de teste com a severidade especificada."""
+    return LogEntry(
+        raw_content=message,
+        severity=severity,
+        timestamp=datetime(2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc),
+        message=message,
+    )
+
+
+def _make_valid_diagnosis_json(n_hypotheses: int = 3) -> str:
+    """Gera JSON válido de AIDiagnosis com n hipóteses."""
+    hypotheses = [
+        {
+            "description": f"Hipótese {i + 1}",
+            "probability": "alta" if i == 0 else "média" if i == 1 else "baixa",
+            "action": f"Ação concreta {i + 1}",
+            "related_line": None,
+        }
+        for i in range(n_hypotheses)
+    ]
+    data = {
+        "summary": "Falha recorrente de conexão com banco de dados.",
+        "probable_cause": "Pool de conexões esgotado.",
+        "hypotheses": hypotheses,
+        "suggested_fix": "Aumentar max_connections no pool.",
+        "confidence": 0.85,
+    }
+    return json.dumps(data)
+
+
+def _make_analysis_result() -> AnalysisResult:
+    """Cria um AnalysisResult de teste."""
+    return AnalysisResult(
+        total_entries=10,
+        error_count=5,
+        warning_count=3,
+        severity_distribution={SeverityLevel.ERROR: 5, SeverityLevel.WARNING: 3, SeverityLevel.INFO: 2},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Testes da interface abstrata AIEngine
+# ---------------------------------------------------------------------------
+
+
+class TestAIEngineInterface:
+    """Testes para a interface abstrata AIEngine."""
+
+    def test_cannot_instantiate_abstract(self) -> None:
+        """AIEngine não pode ser instanciado diretamente."""
+        with pytest.raises(TypeError):
+            AIEngine()  # type: ignore[abstract]
+
+    def test_ollama_engine_is_subclass(self) -> None:
+        """OllamaAIEngine deve ser subclasse de AIEngine."""
+        assert issubclass(OllamaAIEngine, AIEngine)
+
+    def test_subclass_without_diagnose_raises(self) -> None:
+        """Subclasse sem implementar diagnose deve lançar TypeError."""
+
+        class IncompleteEngine(AIEngine):
+            pass
+
+        with pytest.raises(TypeError):
+            IncompleteEngine()  # type: ignore[abstract]
+
+
+# ---------------------------------------------------------------------------
+# Testes de amostragem estratificada
+# ---------------------------------------------------------------------------
+
+
+class TestStratifiedSampling:
+    """Testes para a função de amostragem estratificada."""
+
+    def test_empty_entries_returns_empty(self) -> None:
+        """Lista vazia retorna lista vazia."""
+        assert _stratified_sample([]) == []
+
+    def test_entries_below_max_returned_as_is(self) -> None:
+        """Menos de 50 entradas retorna todas sem amostragem."""
+        entries = [_make_entry(SeverityLevel.ERROR) for _ in range(10)]
+        result = _stratified_sample(entries)
+        assert len(result) == 10
+
+    def test_sampling_caps_at_50_entries(self) -> None:
+        """Amostragem limita a 50 entradas no máximo."""
+        entries = [_make_entry(SeverityLevel.ERROR) for _ in range(200)]
+        result = _stratified_sample(entries)
+        assert len(result) <= _MAX_SAMPLE_ENTRIES
+
+    def test_stratified_70_percent_errors(self) -> None:
+        """Amostragem deve ter ~70% de erros (ERROR/CRITICAL)."""
+        errors = [_make_entry(SeverityLevel.ERROR) for _ in range(100)]
+        warnings = [_make_entry(SeverityLevel.WARNING) for _ in range(100)]
+        others = [_make_entry(SeverityLevel.INFO) for _ in range(100)]
+        entries = errors + warnings + others
+
+        result = _stratified_sample(entries, max_entries=50)
+
+        error_count = sum(1 for e in result if e.severity in {SeverityLevel.ERROR, SeverityLevel.CRITICAL})
+        # Deve ter pelo menos 30 erros (60% mínimo, considerando redistribuição)
+        assert error_count >= 30
+
+    def test_stratified_20_percent_warnings(self) -> None:
+        """Amostragem deve ter ~20% de warnings."""
+        errors = [_make_entry(SeverityLevel.ERROR) for _ in range(100)]
+        warnings = [_make_entry(SeverityLevel.WARNING) for _ in range(100)]
+        others = [_make_entry(SeverityLevel.INFO) for _ in range(100)]
+        entries = errors + warnings + others
+
+        result = _stratified_sample(entries, max_entries=50)
+
+        warning_count = sum(1 for e in result if e.severity == SeverityLevel.WARNING)
+        # Deve ter pelo menos 8 warnings (16% mínimo)
+        assert warning_count >= 8
+
+    def test_stratified_10_percent_others(self) -> None:
+        """Amostragem deve ter ~10% de outros (INFO, DEBUG)."""
+        errors = [_make_entry(SeverityLevel.ERROR) for _ in range(100)]
+        warnings = [_make_entry(SeverityLevel.WARNING) for _ in range(100)]
+        others = [_make_entry(SeverityLevel.INFO) for _ in range(100)]
+        entries = errors + warnings + others
+
+        result = _stratified_sample(entries, max_entries=50)
+
+        other_count = sum(
+            1 for e in result
+            if e.severity not in {SeverityLevel.ERROR, SeverityLevel.CRITICAL, SeverityLevel.WARNING}
+        )
+        # Deve ter pelo menos 3 outros (6% mínimo)
+        assert other_count >= 3
+
+    def test_sampling_with_only_errors(self) -> None:
+        """Amostragem funciona quando só há entradas de erro."""
+        entries = [_make_entry(SeverityLevel.ERROR) for _ in range(100)]
+        result = _stratified_sample(entries, max_entries=50)
+        assert len(result) == 50
+        assert all(e.severity == SeverityLevel.ERROR for e in result)
+
+    def test_sampling_exact_max_entries(self) -> None:
+        """Amostragem retorna exatamente max_entries quando há entradas suficientes."""
+        entries = (
+            [_make_entry(SeverityLevel.ERROR) for _ in range(100)]
+            + [_make_entry(SeverityLevel.WARNING) for _ in range(100)]
+            + [_make_entry(SeverityLevel.INFO) for _ in range(100)]
+        )
+        result = _stratified_sample(entries, max_entries=50)
+        assert len(result) == 50
+
+
+# ---------------------------------------------------------------------------
+# Testes de disponibilidade do Ollama
+# ---------------------------------------------------------------------------
+
+
+class TestOllamaAvailability:
+    """Testes para verificação de disponibilidade do Ollama."""
+
+    @patch("src.ai.ollama_engine.socket.socket")
+    def test_unavailable_raises_error(self, mock_socket_class: MagicMock) -> None:
+        """AIEngineUnavailableError é lançado quando Ollama está indisponível."""
+        mock_sock = MagicMock()
+        mock_sock.connect_ex.return_value = 1  # Conexão recusada
+        mock_socket_class.return_value = mock_sock
+
+        with patch("src.ai.ollama_engine._check_ollama_availability") as mock_check:
+            mock_check.side_effect = AIEngineUnavailableError(
+                "Ollama não está disponível em http://localhost:11434. Execute: ollama serve"
+            )
+            engine = OllamaAIEngine()
+            with pytest.raises(AIEngineUnavailableError) as exc_info:
+                engine.diagnose(_make_analysis_result(), [])
+
+        assert "ollama serve" in str(exc_info.value).lower() or "ollama" in str(exc_info.value).lower()
+
+    @patch("src.ai.ollama_engine._check_ollama_availability")
+    @patch("openai.OpenAI")
+    def test_available_proceeds_to_call(
+        self, mock_openai_class: MagicMock, mock_check: MagicMock
+    ) -> None:
+        """Quando Ollama está disponível, prossegue para chamada ao LLM."""
+        mock_check.return_value = None  # Disponível
+
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.choices[0].message.content = _make_valid_diagnosis_json()
+        mock_client.chat.completions.create.return_value = mock_response
+
+        engine = OllamaAIEngine()
+        engine._client = mock_client
+
+        result = engine.diagnose(_make_analysis_result(), [])
+        assert isinstance(result, AIDiagnosis)
+
+    def test_unavailable_error_message_contains_ollama_serve(self) -> None:
+        """Mensagem de erro deve orientar o usuário a executar 'ollama serve'."""
+        with patch("src.ai.ollama_engine.socket.socket") as mock_socket_class:
+            mock_sock = MagicMock()
+            mock_sock.connect_ex.return_value = 111  # Connection refused
+            mock_socket_class.return_value = mock_sock
+
+            engine = OllamaAIEngine()
+            with pytest.raises(AIEngineUnavailableError) as exc_info:
+                engine.diagnose(_make_analysis_result(), [])
+
+        assert "ollama serve" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Testes de timeout e retry
+# ---------------------------------------------------------------------------
+
+
+class TestTimeoutAndRetry:
+    """Testes para timeout e retry com backoff exponencial."""
+
+    @patch("src.ai.ollama_engine._check_ollama_availability")
+    @patch("src.ai.ollama_engine.time.sleep")
+    def test_timeout_raises_after_3_attempts(
+        self, mock_sleep: MagicMock, mock_check: MagicMock
+    ) -> None:
+        """AIEngineTimeoutError é lançado após 3 tentativas falhadas."""
+        mock_check.return_value = None
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = openai.APITimeoutError(
+            request=MagicMock()
+        )
+
+        engine = OllamaAIEngine()
+        engine._client = mock_client
+
+        with pytest.raises(AIEngineTimeoutError):
+            engine.diagnose(_make_analysis_result(), [])
+
+    @patch("src.ai.ollama_engine._check_ollama_availability")
+    @patch("src.ai.ollama_engine.time.sleep")
+    def test_retry_happens_3_times(
+        self, mock_sleep: MagicMock, mock_check: MagicMock
+    ) -> None:
+        """O cliente deve ser chamado exatamente 3 vezes antes de desistir."""
+        mock_check.return_value = None
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = openai.APITimeoutError(
+            request=MagicMock()
+        )
+
+        engine = OllamaAIEngine()
+        engine._client = mock_client
+
+        with pytest.raises(AIEngineTimeoutError):
+            engine.diagnose(_make_analysis_result(), [])
+
+        assert mock_client.chat.completions.create.call_count == _MAX_RETRIES
+
+    @patch("src.ai.ollama_engine._check_ollama_availability")
+    @patch("src.ai.ollama_engine.time.sleep")
+    def test_backoff_delays_are_correct(
+        self, mock_sleep: MagicMock, mock_check: MagicMock
+    ) -> None:
+        """Backoff exponencial deve usar delays de 1s, 2s (antes das tentativas 2 e 3)."""
+        mock_check.return_value = None
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = openai.APITimeoutError(
+            request=MagicMock()
+        )
+
+        engine = OllamaAIEngine()
+        engine._client = mock_client
+
+        with pytest.raises(AIEngineTimeoutError):
+            engine.diagnose(_make_analysis_result(), [])
+
+        # Deve ter dormido 2 vezes (entre tentativas 1→2 e 2→3)
+        assert mock_sleep.call_count == 2
+        sleep_calls = [call.args[0] for call in mock_sleep.call_args_list]
+        assert sleep_calls == [1, 2]
+
+    @patch("src.ai.ollama_engine._check_ollama_availability")
+    @patch("src.ai.ollama_engine.time.sleep")
+    def test_connection_error_also_retries(
+        self, mock_sleep: MagicMock, mock_check: MagicMock
+    ) -> None:
+        """APIConnectionError também deve acionar retry."""
+        mock_check.return_value = None
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = openai.APIConnectionError(
+            request=MagicMock()
+        )
+
+        engine = OllamaAIEngine()
+        engine._client = mock_client
+
+        with pytest.raises(AIEngineTimeoutError):
+            engine.diagnose(_make_analysis_result(), [])
+
+        assert mock_client.chat.completions.create.call_count == _MAX_RETRIES
+
+
+# ---------------------------------------------------------------------------
+# Testes de parsing e validação de resposta
+# ---------------------------------------------------------------------------
+
+
+class TestResponseParsing:
+    """Testes para parsing e validação da resposta do LLM."""
+
+    @patch("src.ai.ollama_engine._check_ollama_availability")
+    def test_valid_response_parsed_to_ai_diagnosis(self, mock_check: MagicMock) -> None:
+        """Resposta válida é parseada corretamente para AIDiagnosis."""
+        mock_check.return_value = None
+
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.choices[0].message.content = _make_valid_diagnosis_json(3)
+        mock_client.chat.completions.create.return_value = mock_response
+
+        engine = OllamaAIEngine()
+        engine._client = mock_client
+
+        result = engine.diagnose(_make_analysis_result(), [])
+
+        assert isinstance(result, AIDiagnosis)
+        assert result.summary == "Falha recorrente de conexão com banco de dados."
+        assert result.probable_cause == "Pool de conexões esgotado."
+        assert len(result.hypotheses) == 3
+
+    @patch("src.ai.ollama_engine._check_ollama_availability")
+    def test_diagnosis_has_at_least_3_hypotheses(self, mock_check: MagicMock) -> None:
+        """Diagnóstico válido deve ter pelo menos 3 hipóteses."""
+        mock_check.return_value = None
+
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.choices[0].message.content = _make_valid_diagnosis_json(5)
+        mock_client.chat.completions.create.return_value = mock_response
+
+        engine = OllamaAIEngine()
+        engine._client = mock_client
+
+        result = engine.diagnose(_make_analysis_result(), [])
+
+        assert len(result.hypotheses) >= 3
+
+    @patch("src.ai.ollama_engine._check_ollama_availability")
+    def test_response_with_less_than_3_hypotheses_raises_validation_error(
+        self, mock_check: MagicMock
+    ) -> None:
+        """Resposta com menos de 3 hipóteses deve lançar ValidationError."""
+        mock_check.return_value = None
+
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.choices[0].message.content = _make_valid_diagnosis_json(2)
+        mock_client.chat.completions.create.return_value = mock_response
+
+        engine = OllamaAIEngine()
+        engine._client = mock_client
+
+        with pytest.raises(ValidationError):
+            engine.diagnose(_make_analysis_result(), [])
+
+    @patch("src.ai.ollama_engine._check_ollama_availability")
+    def test_response_with_empty_action_raises_validation_error(
+        self, mock_check: MagicMock
+    ) -> None:
+        """Resposta com action vazio em hipótese deve lançar ValidationError."""
+        mock_check.return_value = None
+
+        invalid_json = json.dumps({
+            "summary": "Problema detectado.",
+            "probable_cause": "Causa desconhecida.",
+            "hypotheses": [
+                {"description": "H1", "probability": "alta", "action": "Ação 1"},
+                {"description": "H2", "probability": "média", "action": "Ação 2"},
+                {"description": "H3", "probability": "baixa", "action": ""},  # action vazio
+            ],
+            "suggested_fix": "",
+            "confidence": 0.5,
+        })
+
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.choices[0].message.content = invalid_json
+        mock_client.chat.completions.create.return_value = mock_response
+
+        engine = OllamaAIEngine()
+        engine._client = mock_client
+
+        with pytest.raises(ValidationError):
+            engine.diagnose(_make_analysis_result(), [])
+
+    @patch("src.ai.ollama_engine._check_ollama_availability")
+    def test_response_with_markdown_code_block_is_parsed(self, mock_check: MagicMock) -> None:
+        """Resposta com bloco de código markdown deve ser parseada corretamente."""
+        mock_check.return_value = None
+
+        json_content = _make_valid_diagnosis_json(3)
+        markdown_wrapped = f"```json\n{json_content}\n```"
+
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.choices[0].message.content = markdown_wrapped
+        mock_client.chat.completions.create.return_value = mock_response
+
+        engine = OllamaAIEngine()
+        engine._client = mock_client
+
+        result = engine.diagnose(_make_analysis_result(), [])
+        assert isinstance(result, AIDiagnosis)
+
+    @patch("src.ai.ollama_engine._check_ollama_availability")
+    def test_each_hypothesis_has_non_empty_action(self, mock_check: MagicMock) -> None:
+        """Cada hipótese no diagnóstico deve ter action não vazio."""
+        mock_check.return_value = None
+
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.choices[0].message.content = _make_valid_diagnosis_json(4)
+        mock_client.chat.completions.create.return_value = mock_response
+
+        engine = OllamaAIEngine()
+        engine._client = mock_client
+
+        result = engine.diagnose(_make_analysis_result(), [])
+
+        for hypothesis in result.hypotheses:
+            assert hypothesis.action.strip() != ""
+
+
+# ---------------------------------------------------------------------------
+# Testes de integração do fluxo completo
+# ---------------------------------------------------------------------------
+
+
+class TestOllamaEngineIntegration:
+    """Testes de integração do fluxo completo do OllamaAIEngine."""
+
+    @patch("src.ai.ollama_engine._check_ollama_availability")
+    def test_diagnose_with_sample_entries(self, mock_check: MagicMock) -> None:
+        """diagnose funciona com entradas de amostra reais."""
+        mock_check.return_value = None
+
+        entries = (
+            [_make_entry(SeverityLevel.ERROR, "Database connection failed") for _ in range(10)]
+            + [_make_entry(SeverityLevel.WARNING, "Slow query detected") for _ in range(5)]
+            + [_make_entry(SeverityLevel.INFO, "Request processed") for _ in range(5)]
+        )
+
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.choices[0].message.content = _make_valid_diagnosis_json(3)
+        mock_client.chat.completions.create.return_value = mock_response
+
+        engine = OllamaAIEngine()
+        engine._client = mock_client
+
+        result = engine.diagnose(_make_analysis_result(), entries)
+
+        assert isinstance(result, AIDiagnosis)
+        assert len(result.hypotheses) >= 3
+
+    @patch("src.ai.ollama_engine._check_ollama_availability")
+    def test_diagnose_succeeds_on_second_attempt(self, mock_check: MagicMock) -> None:
+        """diagnose deve ter sucesso na segunda tentativa após falha na primeira."""
+        mock_check.return_value = None
+
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.choices[0].message.content = _make_valid_diagnosis_json(3)
+
+        # Falha na primeira tentativa, sucesso na segunda
+        mock_client.chat.completions.create.side_effect = [
+            openai.APITimeoutError(request=MagicMock()),
+            mock_response,
+        ]
+
+        engine = OllamaAIEngine()
+        engine._client = mock_client
+
+        with patch("src.ai.ollama_engine.time.sleep"):
+            result = engine.diagnose(_make_analysis_result(), [])
+
+        assert isinstance(result, AIDiagnosis)
+        assert mock_client.chat.completions.create.call_count == 2

--- a/tests/analyzer/test_detector.py
+++ b/tests/analyzer/test_detector.py
@@ -1,0 +1,592 @@
+"""Testes unitários e de propriedade para o AnomalyDetector do LogPulse IA.
+
+Cobre todos os critérios de aceitação da Tarefa 5:
+- Interface abstrata LogAnalyzer
+- Agrupamento por template_id
+- Distribuição de severidade
+- Detecção de spikes (janela deslizante de 60s, threshold ≥10)
+- Agrupamento de stack traces (Python, Java, Go)
+- Dados insuficientes (< 2 entradas)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import List, Optional
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from src.analyzer.base import LogAnalyzer
+from src.analyzer.detector import AnomalyDetector
+from src.models.schemas import AnalysisResult, LogEntry, LogTemplate, SeverityLevel
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_BASE_TIME = datetime(2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+
+
+def make_entry(
+    raw_content: str = "test log line",
+    severity: SeverityLevel = SeverityLevel.INFO,
+    timestamp: Optional[datetime] = None,
+    template_id: Optional[str] = None,
+) -> LogEntry:
+    """Cria um LogEntry para uso nos testes."""
+    return LogEntry(
+        raw_content=raw_content,
+        severity=severity,
+        timestamp=timestamp or _BASE_TIME,
+        template_id=template_id,
+    )
+
+
+def make_error_entries_in_window(
+    count: int,
+    window_seconds: int = 59,
+    severity: SeverityLevel = SeverityLevel.ERROR,
+    start_time: Optional[datetime] = None,
+) -> List[LogEntry]:
+    """Cria `count` entradas de erro distribuídas dentro de `window_seconds`."""
+    base = start_time or _BASE_TIME
+    entries = []
+    for i in range(count):
+        if count > 1:
+            offset = timedelta(seconds=i * window_seconds / (count - 1)) if count > 1 else timedelta(0)
+        else:
+            offset = timedelta(0)
+        entries.append(
+            make_entry(
+                raw_content=f"ERROR: failure {i}",
+                severity=severity,
+                timestamp=base + offset,
+            )
+        )
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def detector() -> AnomalyDetector:
+    """Instância limpa do AnomalyDetector para cada teste."""
+    return AnomalyDetector()
+
+
+# ===========================================================================
+# Interface abstrata LogAnalyzer
+# ===========================================================================
+
+
+class TestLogAnalyzerInterface:
+    def test_cannot_instantiate_abstract(self) -> None:
+        """LogAnalyzer não pode ser instanciado diretamente."""
+        with pytest.raises(TypeError):
+            LogAnalyzer()  # type: ignore[abstract]
+
+    def test_anomaly_detector_is_subclass(self) -> None:
+        assert issubclass(AnomalyDetector, LogAnalyzer)
+
+    def test_anomaly_detector_implements_analyze(self) -> None:
+        d = AnomalyDetector()
+        assert callable(d.analyze)
+
+    def test_analyze_returns_analysis_result(self, detector: AnomalyDetector) -> None:
+        entries = [make_entry(), make_entry()]
+        result = detector.analyze(entries, [])
+        assert isinstance(result, AnalysisResult)
+
+
+# ===========================================================================
+# Dados insuficientes
+# ===========================================================================
+
+
+class TestInsufficientData:
+    def test_zero_entries_returns_insufficient_data(self, detector: AnomalyDetector) -> None:
+        """0 entradas → insufficient_data=True."""
+        result = detector.analyze([], [])
+        assert result.insufficient_data is True
+        assert result.total_entries == 0
+
+    def test_one_entry_returns_insufficient_data(self, detector: AnomalyDetector) -> None:
+        """1 entrada → insufficient_data=True."""
+        result = detector.analyze([make_entry()], [])
+        assert result.insufficient_data is True
+        assert result.total_entries == 1
+
+    def test_two_entries_not_insufficient(self, detector: AnomalyDetector) -> None:
+        """2 entradas → insufficient_data=False."""
+        entries = [make_entry(), make_entry()]
+        result = detector.analyze(entries, [])
+        assert result.insufficient_data is False
+
+    def test_ten_entries_not_insufficient(self, detector: AnomalyDetector) -> None:
+        """10 entradas → insufficient_data=False."""
+        entries = [make_entry() for _ in range(10)]
+        result = detector.analyze(entries, [])
+        assert result.insufficient_data is False
+
+    def test_hundred_entries_not_insufficient(self, detector: AnomalyDetector) -> None:
+        """100 entradas → insufficient_data=False."""
+        entries = [make_entry() for _ in range(100)]
+        result = detector.analyze(entries, [])
+        assert result.insufficient_data is False
+
+    def test_insufficient_data_preserves_total_entries(self, detector: AnomalyDetector) -> None:
+        """total_entries é preservado mesmo com dados insuficientes."""
+        result = detector.analyze([make_entry()], [])
+        assert result.total_entries == 1
+
+    def test_insufficient_data_preserves_templates(self, detector: AnomalyDetector) -> None:
+        """Templates são preservados mesmo com dados insuficientes."""
+        template = LogTemplate(template_id="t1", pattern="test <*>", occurrences=1)
+        result = detector.analyze([], [template])
+        assert len(result.templates) == 1
+
+
+# ===========================================================================
+# Distribuição de severidade
+# ===========================================================================
+
+
+class TestSeverityDistribution:
+    def test_single_severity_level(self, detector: AnomalyDetector) -> None:
+        """Distribuição com apenas um nível de severidade."""
+        entries = [make_entry(severity=SeverityLevel.ERROR) for _ in range(5)]
+        entries.append(make_entry(severity=SeverityLevel.INFO))  # garante >= 2
+        result = detector.analyze(entries, [])
+        assert result.severity_distribution[SeverityLevel.ERROR] == 5
+        assert result.severity_distribution[SeverityLevel.INFO] == 1
+
+    def test_distribution_sums_to_total_entries(self, detector: AnomalyDetector) -> None:
+        """Distribuição de severidade soma igual a total_entries."""
+        entries = [
+            make_entry(severity=SeverityLevel.DEBUG),
+            make_entry(severity=SeverityLevel.INFO),
+            make_entry(severity=SeverityLevel.WARNING),
+            make_entry(severity=SeverityLevel.ERROR),
+            make_entry(severity=SeverityLevel.CRITICAL),
+        ]
+        result = detector.analyze(entries, [])
+        total_in_distribution = sum(result.severity_distribution.values())
+        assert total_in_distribution == result.total_entries
+
+    def test_distribution_all_levels(self, detector: AnomalyDetector) -> None:
+        """Todos os níveis de severidade são contabilizados."""
+        entries = []
+        for level in SeverityLevel:
+            entries.append(make_entry(severity=level))
+        result = detector.analyze(entries, [])
+        for level in SeverityLevel:
+            assert result.severity_distribution.get(level, 0) == 1
+
+    def test_error_count_includes_critical(self, detector: AnomalyDetector) -> None:
+        """error_count inclui tanto ERROR quanto CRITICAL."""
+        entries = [
+            make_entry(severity=SeverityLevel.ERROR),
+            make_entry(severity=SeverityLevel.CRITICAL),
+            make_entry(severity=SeverityLevel.INFO),
+        ]
+        result = detector.analyze(entries, [])
+        assert result.error_count == 2
+
+    def test_warning_count_correct(self, detector: AnomalyDetector) -> None:
+        """warning_count conta apenas WARNING."""
+        entries = [
+            make_entry(severity=SeverityLevel.WARNING),
+            make_entry(severity=SeverityLevel.WARNING),
+            make_entry(severity=SeverityLevel.ERROR),
+        ]
+        result = detector.analyze(entries, [])
+        assert result.warning_count == 2
+
+    def test_distribution_with_100_entries(self, detector: AnomalyDetector) -> None:
+        """Distribuição correta com 100 entradas."""
+        entries = []
+        for i in range(100):
+            level = list(SeverityLevel)[i % 5]
+            entries.append(make_entry(severity=level))
+        result = detector.analyze(entries, [])
+        assert result.total_entries == 100
+        assert sum(result.severity_distribution.values()) == 100
+
+
+# ===========================================================================
+# Agrupamento por template_id
+# ===========================================================================
+
+
+class TestTemplateGrouping:
+    def test_entries_grouped_by_template_id(self, detector: AnomalyDetector) -> None:
+        """AnomalyDetector agrupa LogEntry por template_id."""
+        entries = [
+            make_entry(template_id="tmpl-1"),
+            make_entry(template_id="tmpl-1"),
+            make_entry(template_id="tmpl-2"),
+        ]
+        result = detector.analyze(entries, [])
+        # Análise deve completar sem erros e contar corretamente
+        assert result.total_entries == 3
+
+    def test_entries_without_template_id(self, detector: AnomalyDetector) -> None:
+        """Entradas sem template_id são processadas normalmente."""
+        entries = [make_entry(template_id=None), make_entry(template_id=None)]
+        result = detector.analyze(entries, [])
+        assert result.total_entries == 2
+
+    def test_templates_passed_through(self, detector: AnomalyDetector) -> None:
+        """Templates fornecidos são incluídos no resultado."""
+        templates = [
+            LogTemplate(template_id="t1", pattern="error <*>", occurrences=3),
+            LogTemplate(template_id="t2", pattern="info <*>", occurrences=2),
+        ]
+        entries = [make_entry(), make_entry()]
+        result = detector.analyze(entries, templates)
+        assert len(result.templates) == 2
+
+
+# ===========================================================================
+# Detecção de spikes
+# ===========================================================================
+
+
+class TestSpikeDetection:
+    def test_exactly_10_errors_in_60s_detects_spike(self, detector: AnomalyDetector) -> None:
+        """Spike detectado com exatamente 10 erros em 60s."""
+        entries = make_error_entries_in_window(10, window_seconds=59)
+        result = detector.analyze(entries, [])
+        assert len(result.spikes) >= 1
+        assert result.spikes[0].error_count >= 10
+
+    def test_15_errors_in_60s_detects_spike(self, detector: AnomalyDetector) -> None:
+        """Spike detectado com 15 erros em 60s."""
+        entries = make_error_entries_in_window(15, window_seconds=59)
+        result = detector.analyze(entries, [])
+        assert len(result.spikes) >= 1
+
+    def test_9_errors_in_60s_no_spike(self, detector: AnomalyDetector) -> None:
+        """Sem spike com 9 erros em 60s."""
+        entries = make_error_entries_in_window(9, window_seconds=59)
+        result = detector.analyze(entries, [])
+        assert len(result.spikes) == 0
+
+    def test_10_errors_in_61s_no_spike(self, detector: AnomalyDetector) -> None:
+        """Sem spike com 10 erros em 61s (fora da janela de 60s)."""
+        base = _BASE_TIME
+        entries = []
+        for i in range(10):
+            # Distribui 10 erros em 61 segundos (cada um separado por ~6.8s)
+            offset = timedelta(seconds=i * 61 / 9)
+            entries.append(
+                make_entry(
+                    raw_content=f"ERROR: failure {i}",
+                    severity=SeverityLevel.ERROR,
+                    timestamp=base + offset,
+                )
+            )
+        result = detector.analyze(entries, [])
+        assert len(result.spikes) == 0
+
+    def test_spike_error_count_correct(self, detector: AnomalyDetector) -> None:
+        """error_count do spike reflete o número de erros na janela."""
+        entries = make_error_entries_in_window(12, window_seconds=30)
+        result = detector.analyze(entries, [])
+        assert len(result.spikes) >= 1
+        assert result.spikes[0].error_count == 12
+
+    def test_spike_with_critical_severity(self, detector: AnomalyDetector) -> None:
+        """CRITICAL também conta para detecção de spike."""
+        entries = make_error_entries_in_window(10, window_seconds=59, severity=SeverityLevel.CRITICAL)
+        result = detector.analyze(entries, [])
+        assert len(result.spikes) >= 1
+
+    def test_spike_mixed_error_and_critical(self, detector: AnomalyDetector) -> None:
+        """Mistura de ERROR e CRITICAL conta para spike."""
+        base = _BASE_TIME
+        entries = []
+        for i in range(5):
+            entries.append(make_entry(severity=SeverityLevel.ERROR, timestamp=base + timedelta(seconds=i * 5)))
+        for i in range(5):
+            entries.append(make_entry(severity=SeverityLevel.CRITICAL, timestamp=base + timedelta(seconds=25 + i * 5)))
+        result = detector.analyze(entries, [])
+        assert len(result.spikes) >= 1
+
+    def test_warnings_do_not_trigger_spike(self, detector: AnomalyDetector) -> None:
+        """WARNING não conta para detecção de spike."""
+        entries = make_error_entries_in_window(15, window_seconds=30, severity=SeverityLevel.WARNING)
+        result = detector.analyze(entries, [])
+        assert len(result.spikes) == 0
+
+    def test_info_does_not_trigger_spike(self, detector: AnomalyDetector) -> None:
+        """INFO não conta para detecção de spike."""
+        entries = make_error_entries_in_window(20, window_seconds=30, severity=SeverityLevel.INFO)
+        result = detector.analyze(entries, [])
+        assert len(result.spikes) == 0
+
+    def test_spike_start_time_before_end_time(self, detector: AnomalyDetector) -> None:
+        """Spike tem start_time < end_time."""
+        entries = make_error_entries_in_window(10, window_seconds=30)
+        result = detector.analyze(entries, [])
+        assert len(result.spikes) >= 1
+        for spike in result.spikes:
+            assert spike.end_time > spike.start_time
+
+    def test_no_spike_with_zero_errors(self, detector: AnomalyDetector) -> None:
+        """Sem erros → sem spike."""
+        entries = [make_entry(severity=SeverityLevel.INFO) for _ in range(20)]
+        result = detector.analyze(entries, [])
+        assert len(result.spikes) == 0
+
+    def test_spike_with_template_ids(self, detector: AnomalyDetector) -> None:
+        """Spike inclui template_ids das entradas envolvidas."""
+        base = _BASE_TIME
+        entries = []
+        for i in range(10):
+            entries.append(
+                make_entry(
+                    severity=SeverityLevel.ERROR,
+                    timestamp=base + timedelta(seconds=i * 5),
+                    template_id="tmpl-error",
+                )
+            )
+        result = detector.analyze(entries, [])
+        assert len(result.spikes) >= 1
+        assert "tmpl-error" in result.spikes[0].template_ids
+
+
+# ===========================================================================
+# Agrupamento de stack traces
+# ===========================================================================
+
+
+class TestStackTraceDetection:
+    def test_python_traceback_grouped_in_one_event(self, detector: AnomalyDetector) -> None:
+        """Python traceback multi-linha agrupado em 1 evento."""
+        entries = [
+            make_entry(raw_content="Traceback (most recent call last):"),
+            make_entry(raw_content='  File "app.py", line 42, in main'),
+            make_entry(raw_content="    result = process()"),
+            make_entry(raw_content="ValueError: invalid input"),
+        ]
+        result = detector.analyze(entries, [])
+        assert len(result.stack_traces) == 1
+        assert "Traceback" in result.stack_traces[0]
+
+    def test_java_stacktrace_grouped_in_one_event(self, detector: AnomalyDetector) -> None:
+        """Java stacktrace multi-linha agrupado em 1 evento."""
+        entries = [
+            make_entry(raw_content="Exception in thread main java.lang.NullPointerException"),
+            make_entry(raw_content="    at com.example.App.main(App.java:10)"),
+            make_entry(raw_content="    at com.example.App.run(App.java:20)"),
+        ]
+        result = detector.analyze(entries, [])
+        assert len(result.stack_traces) == 1
+        assert "Exception in thread" in result.stack_traces[0]
+
+    def test_go_panic_grouped_in_one_event(self, detector: AnomalyDetector) -> None:
+        """Go panic multi-linha agrupado em 1 evento."""
+        entries = [
+            make_entry(raw_content="panic: runtime error: index out of range"),
+            make_entry(raw_content="goroutine 1 [running]:"),
+            make_entry(raw_content="\tmain.main()"),
+        ]
+        result = detector.analyze(entries, [])
+        assert len(result.stack_traces) == 1
+        assert "panic:" in result.stack_traces[0]
+
+    def test_python_traceback_preserves_order(self, detector: AnomalyDetector) -> None:
+        """Linhas do traceback Python são preservadas em ordem."""
+        lines = [
+            "Traceback (most recent call last):",
+            "File app.py line 10 in handler",
+            "RuntimeError: oops",
+        ]
+        entries = [make_entry(raw_content=line) for line in lines]
+        result = detector.analyze(entries, [])
+        assert len(result.stack_traces) == 1
+        trace = result.stack_traces[0]
+        assert trace.index("Traceback") < trace.index("RuntimeError")
+
+    def test_no_stack_traces_in_normal_logs(self, detector: AnomalyDetector) -> None:
+        """Logs normais não geram stack traces."""
+        entries = [
+            make_entry(raw_content="INFO: server started"),
+            make_entry(raw_content="INFO: request received"),
+            make_entry(raw_content="ERROR: connection refused"),
+        ]
+        result = detector.analyze(entries, [])
+        assert len(result.stack_traces) == 0
+
+    def test_multiple_stack_traces_detected(self, detector: AnomalyDetector) -> None:
+        """Múltiplos stack traces são detectados separadamente."""
+        entries = [
+            make_entry(raw_content="Traceback (most recent call last):"),
+            make_entry(raw_content='  File "a.py", line 1, in foo'),
+            make_entry(raw_content="ValueError: first error"),
+            make_entry(raw_content="INFO: recovered"),
+            make_entry(raw_content="Traceback (most recent call last):"),
+            make_entry(raw_content='  File "b.py", line 2, in bar'),
+            make_entry(raw_content="TypeError: second error"),
+        ]
+        result = detector.analyze(entries, [])
+        assert len(result.stack_traces) == 2
+
+    def test_java_stacktrace_continuation_lines(self, detector: AnomalyDetector) -> None:
+        """Linhas 'at ...' continuam o stacktrace Java."""
+        entries = [
+            make_entry(raw_content="Exception in thread main java.io.IOException"),
+            make_entry(raw_content="    at java.io.FileInputStream.open(FileInputStream.java:195)"),
+            make_entry(raw_content="    at java.io.FileInputStream.<init>(FileInputStream.java:138)"),
+            make_entry(raw_content="Caused by: java.io.FileNotFoundException: file.txt"),
+        ]
+        result = detector.analyze(entries, [])
+        assert len(result.stack_traces) == 1
+        assert "Caused by" in result.stack_traces[0]
+
+    def test_go_panic_goroutine_continuation(self, detector: AnomalyDetector) -> None:
+        """Linhas goroutine continuam o panic Go."""
+        entries = [
+            make_entry(raw_content="panic: nil pointer dereference"),
+            make_entry(raw_content="goroutine 1 [running]:"),
+            make_entry(raw_content="\tmain.handler(0xc000012345)"),
+        ]
+        result = detector.analyze(entries, [])
+        assert len(result.stack_traces) == 1
+
+
+# ===========================================================================
+# Casos de borda: 0, 1, 2, 10, 100 entradas
+# ===========================================================================
+
+
+class TestEntryCounts:
+    def test_zero_entries(self, detector: AnomalyDetector) -> None:
+        """0 entradas → resultado válido com insufficient_data=True."""
+        result = detector.analyze([], [])
+        assert result.total_entries == 0
+        assert result.insufficient_data is True
+        assert result.spikes == []
+        assert result.stack_traces == []
+
+    def test_one_entry(self, detector: AnomalyDetector) -> None:
+        """1 entrada → resultado válido com insufficient_data=True."""
+        result = detector.analyze([make_entry()], [])
+        assert result.total_entries == 1
+        assert result.insufficient_data is True
+
+    def test_two_entries(self, detector: AnomalyDetector) -> None:
+        """2 entradas → análise completa sem insufficient_data."""
+        entries = [make_entry(), make_entry()]
+        result = detector.analyze(entries, [])
+        assert result.total_entries == 2
+        assert result.insufficient_data is False
+        assert sum(result.severity_distribution.values()) == 2
+
+    def test_ten_entries(self, detector: AnomalyDetector) -> None:
+        """10 entradas → análise completa."""
+        entries = [make_entry() for _ in range(10)]
+        result = detector.analyze(entries, [])
+        assert result.total_entries == 10
+        assert result.insufficient_data is False
+        assert sum(result.severity_distribution.values()) == 10
+
+    def test_hundred_entries(self, detector: AnomalyDetector) -> None:
+        """100 entradas → análise completa."""
+        entries = [make_entry() for _ in range(100)]
+        result = detector.analyze(entries, [])
+        assert result.total_entries == 100
+        assert result.insufficient_data is False
+        assert sum(result.severity_distribution.values()) == 100
+
+
+# ===========================================================================
+# Property-based tests (hypothesis)
+# ===========================================================================
+
+_severity_strategy = st.sampled_from(list(SeverityLevel))
+
+
+@given(
+    n=st.integers(min_value=2, max_value=100),
+    severities=st.lists(
+        st.sampled_from(list(SeverityLevel)),
+        min_size=2,
+        max_size=100,
+    ),
+)
+@settings(max_examples=50)
+def test_severity_distribution_always_sums_to_total_entries(
+    n: int, severities: list[SeverityLevel]
+) -> None:
+    """**Validates: Requirements RF-04.4**
+
+    Propriedade: distribuição de severidade sempre soma igual a total_entries.
+    """
+    detector = AnomalyDetector()
+    entries = [
+        make_entry(severity=severities[i % len(severities)])
+        for i in range(len(severities))
+    ]
+    result = detector.analyze(entries, [])
+    if not result.insufficient_data:
+        total_in_dist = sum(result.severity_distribution.values())
+        assert total_in_dist == result.total_entries
+
+
+@given(n=st.integers(min_value=0, max_value=1))
+@settings(max_examples=20)
+def test_insufficient_data_always_true_when_less_than_2(n: int) -> None:
+    """**Validates: Requirements RF-04.5**
+
+    Propriedade: insufficient_data=True sempre que há < 2 entradas.
+    """
+    detector = AnomalyDetector()
+    entries = [make_entry() for _ in range(n)]
+    result = detector.analyze(entries, [])
+    assert result.insufficient_data is True
+
+
+@given(
+    extra=st.integers(min_value=0, max_value=20),
+)
+@settings(max_examples=30)
+def test_spike_always_has_error_count_gte_10(extra: int) -> None:
+    """**Validates: Requirements RF-04.2**
+
+    Propriedade: todo spike detectado tem error_count >= 10.
+    """
+    detector = AnomalyDetector()
+    base = _BASE_TIME
+    count = 10 + extra
+    entries = []
+    for i in range(count):
+        offset = timedelta(seconds=i * 59 / max(count - 1, 1))
+        entries.append(
+            make_entry(
+                severity=SeverityLevel.ERROR,
+                timestamp=base + offset,
+            )
+        )
+    result = detector.analyze(entries, [])
+    for spike in result.spikes:
+        assert spike.error_count >= 10
+
+
+@given(
+    n=st.integers(min_value=2, max_value=50),
+)
+@settings(max_examples=30)
+def test_total_entries_always_matches_input_length(n: int) -> None:
+    """Propriedade: total_entries sempre reflete o número de entradas fornecidas."""
+    detector = AnomalyDetector()
+    entries = [make_entry() for _ in range(n)]
+    result = detector.analyze(entries, [])
+    assert result.total_entries == n


### PR DESCRIPTION
Closes #273

Implementa Tarefa 6: AIEngine com Ollama/LLaMA 3 via OpenAI SDK.

Arquivos criados:
- src/ai/base.py - interface abstrata AIEngine (fecha #274)
- src/ai/ollama_engine.py - OllamaAIEngine com retry, timeout, amostragem estratificada (fecha #275, #276, #277)
- src/exceptions.py - hierarquia de excecoes customizadas (fecha #290)
- tests/ai/test_ollama_engine.py - 26 testes com mock
- docs/prompts/04, 05, 07 - documentacao de prompts

216 testes passando. Requisitos: RF-05.1, RF-05.2, RF-05.3, RF-05.5, RF-05.7, RNF-04, RNF-08